### PR TITLE
fix : UserRoleのプレフィックスをuuidの中にいれた

### DIFF
--- a/src/laravel/app/Domain/ValueObjects/UserRoleId.php
+++ b/src/laravel/app/Domain/ValueObjects/UserRoleId.php
@@ -7,11 +7,11 @@ use Ramsey\Uuid\Uuid;
 class UserRoleId
 {
   private string $userRoleId;
-
+  private string $prefix = 'userRole';
   public function __construct(?string $userRoleId = null)
   {
     if (is_null($userRoleId)) {
-      $this->userRoleId = 'user-role-' . Uuid::uuid4()->toString();
+      $this->userRoleId = $this->prefix . substr(Uuid::uuid4()->toString(), 8);
     } else {
       $this->validate($userRoleId);
       $this->userRoleId = $userRoleId;
@@ -21,17 +21,14 @@ class UserRoleId
   public function validate(string $userRoleId): void
   {
     // user-role-で始まっていない場合はエラー
-    if (!str_starts_with($userRoleId, 'user-role-')) {
-      throw new \InvalidArgumentException('UserRoleIdはuser-role-から始まる必要があります。');
+    if (!str_starts_with($userRoleId, $this->prefix)) {
+      throw new \InvalidArgumentException('UserRoleIdは' . $this->prefix . 'から始まる必要があります。');
     }
 
-    // user-role-を取り外す
-    $trimmedUserRoleId = str_replace('user-role-', '', $userRoleId);
-
     // uuid v4の形式
-    $uuidRegex = '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/';
-    if (!preg_match($uuidRegex, $trimmedUserRoleId)) {
-      throw new \InvalidArgumentException('UUID v4の形式ではありません。');
+    $uuidRegex = '/^' . $this->prefix . '-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/';
+    if (!preg_match($uuidRegex, $userRoleId)) {
+      throw new \InvalidArgumentException('UserRoleIdの形式が正しくありません。' . $this->prefix . 'で始まるUUID v4形式である必要があります。');
     }
   }
 

--- a/src/laravel/tests/Unit/Domain/ValueObjects/UserRoleIdTest.php
+++ b/src/laravel/tests/Unit/Domain/ValueObjects/UserRoleIdTest.php
@@ -8,13 +8,21 @@ use Ramsey\Uuid\Uuid;
 
 class UserRoleIdTest extends TestCase
 {
+  private string $prefix = 'userRole';
+
+  public function setUp(): void
+  {
+    parent::setUp();
+    config()->set('logging.default', 'stderr');
+  }
+
   /**
    * @test
    */
   public function testToString(): void
   {
     // Given
-    $userId = "user-role-" . Uuid::uuid4()->toString();
+    $userId = $this->prefix . substr(Uuid::uuid4()->toString(), 8);
 
     // When
     $userIdValueObject = new UserRoleId($userId);
@@ -29,7 +37,7 @@ class UserRoleIdTest extends TestCase
   public function testInvalidUserIdFormat(): void
   {
     // Given
-    $userId = "user-role-invalid-user-id-format";
+    $userId = $this->prefix . "-invalid-user-id-format";
 
     // When & Then
     $this->expectException(\InvalidArgumentException::class);
@@ -55,7 +63,7 @@ class UserRoleIdTest extends TestCase
   public function testInvalidUserIdUuidVersion(): void
   {
     // Given
-    $userId = 'user-role-' . Uuid::uuid3(Uuid::NAMESPACE_URL, 'example.com')->toString();
+    $userId = $this->prefix . '-' . Uuid::uuid3(Uuid::NAMESPACE_URL, 'example.com')->toString();
 
     // When & Then
     $this->expectException(\InvalidArgumentException::class);
@@ -71,6 +79,6 @@ class UserRoleIdTest extends TestCase
     $userIdValueObject = new UserRoleId();
 
     // Then
-    $this->assertStringStartsWith('user-role-', $userIdValueObject->toString());
+    $this->assertStringStartsWith($this->prefix, $userIdValueObject->toString());
   }
 }


### PR DESCRIPTION
## 実施タスク
[対象のissue] : <!-- ここを置き換える --> #106 

## 実施内容
<!-- 作成内容・何を変更したか -->
<!-- 過去形で箇条書きで記載する -->

<!-- 例： -->
<!-- - 管理画面の作成を行いました -->
<!-- - 管理画面周りのUIテストコードを追加しました -->
- userRole-3bff-42d5-b4b5-bde4a2cf4ec5 
- 上のような形式でuuidの内部に識別空間を用意した
## レビューしてほしいこと
<!-- 実装した箇所の明示 -->
<!-- 全体としてコードについてよりかは実装結果・内容について聞く -->
### 実装した箇所
<!-- 変更したURLパス・対象の画像 -->

<!-- 例： -->
<!-- 変更したURLパス -->

<!-- 【変更前の対象の画像】 -->
<!-- 画像パス -->

<!-- 【変更後の対象の画像】 -->
<!-- 画像パス -->

### 重点的にレビューしてほしいこと
<!-- **レビューしてほしい内容：** -->
<!-- 箇条書きでレビュー方法を記載する -->

<!-- 例 -->
<!-- テストケースに過不足がないこと -->

## 備考
<!-- 実装できていない点・不安・今後の予定などを記載する -->

<!-- 例 -->
<!-- - 管理画面で表示するモーダルについては、別PRで実装を行います -->
