### PR TITLE
272 差し込みpolicygroupを作成することでpolicyの管理を容易にする

### DIFF
--- a/docs/Userのドメインイメージ.md
+++ b/docs/Userのドメインイメージ.md
@@ -29,6 +29,8 @@
      - ID: RoleId (値オブジェクト)
      - Name: RoleName (値オブジェクト)
      - Description: RoleDescription (値オブジェクト)
+     - Policies: PolicyIdCollection (値オブジェクト)
+     - PolicyGroups: PolicyGroupIdCollection (値オブジェクト)
 
 4. Policy（ポリシー）
 
@@ -45,6 +47,13 @@
      - RoleId: RoleId (値オブジェクト)
      - AssignedAt: DateTime
      - AssignedBy: UserId (値オブジェクト)
+
+6. PolicyGroup（ポリシーグループ）
+   - 属性:
+     - ID: PolicyGroupId (値オブジェクト)
+     - Name: PolicyGroupName (値オブジェクト)
+     - Description: PolicyGroupDescription (値オブジェクト)
+     - Policies: PolicyIdCollection (値オブジェクト)
 
 ## 値オブジェクト
 
@@ -133,13 +142,32 @@
     - userRoleから始まるUUIDv4
     - example: userRole-e89b-12d3-a456-426614174000
 
+18. PolicyGroupId
+    - policyGroup から始まる UUIDv4
+    - example: policyGroup-e89b-12d3-a456-426614174000
+    - 一意制約
+
+19. PolicyGroupName
+    - 文字列（1文字以上50文字以下）
+
+20. PolicyGroupDescription
+    - 文字列（0文字以上255文字以下）
+
+21. PolicyIdCollection
+    - PolicyId の配列
+    - 重複を許可しない
+
+22. PolicyGroupIdCollection
+    - PolicyGroupId の配列
+    - 重複を許可しない
+
 ## 集約
 
 1. User 集約
 
-   - ルートエンティティ: User
-   - 含まれるエンティティ: Profile
-   - 含まれる値オブジェクト: UserId, Username, EmailAddress, HashedPassword, UserStatus
+   - ルートエンティティ: Role
+   - 含まれるエンティティ: なし
+   - 含まれる値オブジェクト: RoleId, RoleName, RoleDescription, PolicyIdCollection, PolicyGroupIdCollection
 
 2. Role 集約
 
@@ -152,8 +180,15 @@
    - 含まれるエンティティ: なし
    - 含まれる値オブジェクト: PolicyId, PolicyName, PolicyDescription, PolicyDocument
 
+4. PolicyGroup 集約
+   - ルートエンティティ: PolicyGroup
+   - 含まれるエンティティ: なし
+   - 含まれる値オブジェクト: PolicyGroupId, PolicyGroupName, PolicyGroupDescription, PolicyIdCollection
+
 ## リレーションシップ
 
 1. User - Profile: 一対一
-2. User - Role: 多対多
+2. User - Role: 多対多 (UserRole エンティティを介して)
 3. Role - Policy: 多対多
+4. Role - PolicyGroup: 多対多
+5. PolicyGroup - Policy: 多対多

--- a/src/laravel/app/Domain/Entities/PolicyGroup.php
+++ b/src/laravel/app/Domain/Entities/PolicyGroup.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Domain\Entities;
+
+use App\Domain\ValueObjects\PolicyGroupDescription;
+use App\Domain\ValueObjects\PolicyGroupId;
+use App\Domain\ValueObjects\PolicyGroupName;
+use App\Domain\ValueObjects\PolicyId;
+use App\Domain\ValueObjects\PolicyIdCollection;
+
+class PolicyGroup
+{
+  private PolicyGroupId $id;
+  private PolicyGroupName $name;
+  private PolicyGroupDescription $description;
+  private PolicyIdCollection $policies;
+
+  public function __construct(
+    PolicyGroupId $id,
+    PolicyGroupName $name,
+    PolicyGroupDescription $description,
+    PolicyIdCollection $policies
+  ) {
+    $this->id = $id;
+    $this->name = $name;
+    $this->description = $description;
+    $this->policies = $policies;
+  }
+
+  public function getId(): PolicyGroupId
+  {
+    return $this->id;
+  }
+
+  public function getName(): PolicyGroupName
+  {
+    return $this->name;
+  }
+
+  public function getDescription(): PolicyGroupDescription
+  {
+    return $this->description;
+  }
+
+  public function getPolicies(): PolicyIdCollection
+  {
+    return $this->policies;
+  }
+
+  public function addPolicy(PolicyId $policyId): void
+  {
+    if (!$this->policies->contains($policyId)) {
+      $this->policies = $this->policies->add($policyId);
+    }
+  }
+
+  public function removePolicy(PolicyId $policyId): void
+  {
+    $this->policies = $this->policies->remove($policyId);
+  }
+}

--- a/src/laravel/app/Domain/Entities/Role.php
+++ b/src/laravel/app/Domain/Entities/Role.php
@@ -2,6 +2,7 @@
 
 namespace App\Domain\Entities;
 
+use App\Domain\ValueObjects\PolicyGroupIdCollection;
 use App\Domain\ValueObjects\PolicyIdCollection;
 use App\Domain\ValueObjects\RoleDescription;
 use App\Domain\ValueObjects\RoleId;
@@ -13,13 +14,20 @@ class Role
   private RoleName $name;
   private RoleDescription $description;
   private PolicyIdCollection $policies;
+  private PolicyGroupIdCollection $policyGroups;
 
-  public function __construct(RoleId $id, RoleName $name, RoleDescription $description, PolicyIdCollection $policies)
-  {
+  public function __construct(
+    RoleId $id,
+    RoleName $name,
+    RoleDescription $description,
+    PolicyIdCollection $policies,
+    PolicyGroupIdCollection $policyGroups
+  ) {
     $this->id = $id;
     $this->name = $name;
     $this->description = $description;
     $this->policies = $policies;
+    $this->policyGroups = $policyGroups;
   }
 
   public function getId(): RoleId
@@ -40,5 +48,10 @@ class Role
   public function getPolicies(): PolicyIdCollection
   {
     return $this->policies;
+  }
+
+  public function getPolicyGroups(): PolicyGroupIdCollection
+  {
+    return $this->policyGroups;
   }
 }

--- a/src/laravel/app/Domain/Repositories/PolicyGroupRepositoryInterface.php
+++ b/src/laravel/app/Domain/Repositories/PolicyGroupRepositoryInterface.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Domain\Repositories;
+
+use App\Domain\Entities\PolicyGroup;
+use App\Domain\ValueObjects\PolicyGroupId;
+use App\Domain\ValueObjects\PolicyGroupIdCollection;
+use App\Domain\ValueObjects\PolicyGroupName;
+use App\Domain\ValueObjects\PolicyId;
+use App\Domain\ValueObjects\PolicyIdCollection;
+
+interface PolicyGroupRepositoryInterface
+{
+  /**
+   * Get all PolicyGroups
+   *
+   * @return PolicyGroupIdCollection
+   */
+  public function all(): PolicyGroupIdCollection;
+
+  /**
+   * Find a PolicyGroup by id
+   *
+   * @param PolicyGroupId $id
+   * @return PolicyGroup|null
+   */
+  public function findById(PolicyGroupId $id): ?PolicyGroup;
+
+  /**
+   * Find a PolicyGroup by name
+   *
+   * @param PolicyGroupName $name
+   * @return PolicyGroup|null
+   */
+  public function findByName(PolicyGroupName $name): ?PolicyGroup;
+
+  /**
+   * Save a PolicyGroup
+   *
+   * @param PolicyGroup $policyGroup
+   * @return void
+   */
+  public function save(PolicyGroup $policyGroup): void;
+
+  /**
+   * Delete a PolicyGroup
+   *
+   * @param PolicyGroup $policyGroup
+   * @return void
+   */
+  public function delete(PolicyGroup $policyGroup): void;
+
+  /**
+   * Get Policies associated with a PolicyGroup
+   *
+   * @param PolicyGroupId $id
+   * @return PolicyIdCollection
+   */
+  public function getPolicies(PolicyGroupId $id): PolicyIdCollection;
+
+  /**
+   * Add a Policy to a PolicyGroup
+   *
+   * @param PolicyGroupId $groupId
+   * @param PolicyId $policyId
+   * @return void
+   */
+  public function addPolicy(PolicyGroupId $groupId, PolicyId $policyId): void;
+
+  /**
+   * Remove a Policy from a PolicyGroup
+   *
+   * @param PolicyGroupId $groupId
+   * @param PolicyId $policyId
+   * @return void
+   */
+  public function removePolicy(PolicyGroupId $groupId, PolicyId $policyId): void;
+}

--- a/src/laravel/app/Domain/ValueObjects/PolicyGroupDescription.php
+++ b/src/laravel/app/Domain/ValueObjects/PolicyGroupDescription.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Domain\ValueObjects;
+
+class PolicyGroupDescription
+{
+  private string $description;
+
+  public function __construct(string $description)
+  {
+    $this->validate($description);
+    $this->description = $description;
+  }
+
+  private function validate(string $description): void
+  {
+    if (mb_strlen($description) > 255) {
+      throw new \InvalidArgumentException('PolicyGroupDescription は255文字以下である必要があります。');
+    }
+  }
+
+  public function toString(): string
+  {
+    return $this->description;
+  }
+}

--- a/src/laravel/app/Domain/ValueObjects/PolicyGroupId.php
+++ b/src/laravel/app/Domain/ValueObjects/PolicyGroupId.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Domain\ValueObjects;
+
+use Illuminate\Support\Facades\Log;
+use Ramsey\Uuid\Uuid;
+
+class PolicyGroupId
+{
+  private string $policyGroupId;
+  private string $prefix = 'policyGp';
+
+  public function __construct(?string $policyGroupId = null)
+  {
+    if (is_null($policyGroupId)) {
+      // UUID v4 を生成し、最初の8文字を 'policyGp' で置換
+      $uuid = Uuid::uuid4()->toString();
+      $this->policyGroupId = $this->prefix . substr($uuid, 8);
+    } else {
+      $this->validate($policyGroupId);
+      $this->policyGroupId = $policyGroupId;
+    }
+    Log::info('class : PolicyGroupId - method : constructor - $policyGroupId : ' . $this->policyGroupId);
+  }
+
+  public function validate(string $policyGroupId): void
+  {
+    // UUID v4 の形式で、最初の8文字が 'policyGp' であることを確認
+    $uuidRegex = '/^' . $this->prefix . '-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/';
+    if (!preg_match($uuidRegex, $policyGroupId)) {
+      Log::error('class : PolicyGroupId - method : validate - $policyGroupId : ' . $policyGroupId);
+      throw new \InvalidArgumentException("policyGroupIdの形式が正しくありません。$this->prefix で始まるUUID v4形式である必要があります。");
+    }
+    Log::info('class : PolicyGroupId - method : validate - $policyGroupId : ' . $policyGroupId);
+  }
+
+  public function toString(): string
+  {
+    Log::info('class : PolicyGroupId - method : toString - $policyGroupId : ' . $this->policyGroupId);
+    return $this->policyGroupId;
+  }
+
+  public function equals(policyGroupId $other): bool
+  {
+    return $other->policyGroupId === $this->policyGroupId;
+  }
+}

--- a/src/laravel/app/Domain/ValueObjects/PolicyGroupIdCollection.php
+++ b/src/laravel/app/Domain/ValueObjects/PolicyGroupIdCollection.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Domain\ValueObjects;
+
+class PolicyGroupIdCollection
+{
+  private $policyGroupIds = [];
+  public function __construct(array $policyGroupIds)
+  {
+    $this->validate($policyGroupIds);
+    $this->policyGroupIds = $policyGroupIds;
+  }
+
+  private function validate($policyGroupIds): void
+  {
+    foreach ($policyGroupIds as $policyGroupId) {
+      if (!$policyGroupId instanceof PolicyGroupId) {
+        throw new \InvalidArgumentException("PolicyGroupIdCollection は、PolicyGroupIdの配列である必要があります");
+      }
+    }
+  }
+
+  public function toArray(): array
+  {
+    return $this->policyGroupIds;
+  }
+
+  public function add(PolicyGroupId $policyGroupId): self
+  {
+    $newPolicyGroupIds = $this->policyGroupIds;
+    $newPolicyGroupIds[] = $policyGroupId;
+    return new self($newPolicyGroupIds);
+  }
+
+  public function remove(PolicyGroupId $policyGroupId): self
+  {
+    $newPolicyGroupIds = array_filter($this->policyGroupIds, fn($id) => !$id->equals($policyGroupId));
+    return new self($newPolicyGroupIds);
+  }
+
+  public function contains(PolicyGroupId $policyGroupId): bool
+  {
+    foreach ($this->policyGroupIds as $id) {
+      if ($id->equals($policyGroupId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  
+  public function count(): int
+  {
+    return count($this->policyGroupIds);
+  }
+}

--- a/src/laravel/app/Domain/ValueObjects/PolicyGroupName.php
+++ b/src/laravel/app/Domain/ValueObjects/PolicyGroupName.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Domain\ValueObjects;
+
+class PolicyGroupName
+{
+  private string $name;
+
+  public function __construct(string $name)
+  {
+    $this->validate($name);
+    $this->name = $name;
+  }
+
+  private function validate(string $name): void
+  {
+    if (empty($name)) {
+      throw new \InvalidArgumentException('PolicyGroupNameは1文字以上50文字以下である必要があります。');
+    }
+
+    if (strlen($name) > 50) {
+      throw new \InvalidArgumentException('PolicyGroupNameは50文字以下である必要があります。');
+    }
+  }
+
+  public function toString(): string
+  {
+    return $this->name;
+  }
+}

--- a/src/laravel/app/Infrastructure/Persistence/EloquentPolicyGroupRepository.php
+++ b/src/laravel/app/Infrastructure/Persistence/EloquentPolicyGroupRepository.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Infrastructure\Persistence;
+
+use App\Domain\Entities\PolicyGroup;
+use App\Domain\ValueObjects\PolicyGroupId;
+use App\Domain\ValueObjects\PolicyGroupIdCollection;
+use App\Domain\ValueObjects\PolicyGroupName;
+use App\Domain\ValueObjects\PolicyGroupDescription;
+use App\Domain\ValueObjects\PolicyId;
+use App\Domain\ValueObjects\PolicyIdCollection;
+use App\Models\EloquentPolicyGroup;
+use App\Models\EloquentPolicy;
+use App\Domain\Repositories\PolicyGroupRepositoryInterface;
+
+class EloquentPolicyGroupRepository implements PolicyGroupRepositoryInterface
+{
+  public function all(): PolicyGroupIdCollection
+  {
+    $policyGroupIds = EloquentPolicyGroup::all()->map(function (EloquentPolicyGroup $eloquentPolicyGroup) {
+      return new PolicyGroupId($eloquentPolicyGroup->id);
+    })->toArray();
+
+    return new PolicyGroupIdCollection($policyGroupIds);
+  }
+
+  public function findById(PolicyGroupId $id): ?PolicyGroup
+  {
+    $eloquentPolicyGroup = EloquentPolicyGroup::find($id->toString());
+    return $eloquentPolicyGroup ? $this->toDomainEntity($eloquentPolicyGroup) : null;
+  }
+
+  public function findByName(PolicyGroupName $name): ?PolicyGroup
+  {
+    $eloquentPolicyGroup = EloquentPolicyGroup::where('name', $name->toString())->first();
+    return $eloquentPolicyGroup ? $this->toDomainEntity($eloquentPolicyGroup) : null;
+  }
+
+  public function save(PolicyGroup $policyGroup): void
+  {
+    $eloquentPolicyGroup = EloquentPolicyGroup::find($policyGroup->getId()->toString());
+
+    if (!$eloquentPolicyGroup) {
+      $eloquentPolicyGroup = new EloquentPolicyGroup();
+      $eloquentPolicyGroup->id = $policyGroup->getId()->toString();
+    }
+
+    $eloquentPolicyGroup->name = $policyGroup->getName()->toString();
+    $eloquentPolicyGroup->description = $policyGroup->getDescription()->toString();
+
+    $eloquentPolicyGroup->save();
+
+    // ポリシーの関連付けを更新
+    $policyIds = $policyGroup->getPolicies()->toArray();
+    $eloquentPolicyGroup->policies()->sync(array_map(function ($policyId) {
+      return $policyId->toString();
+    }, $policyIds));
+  }
+
+  public function delete(PolicyGroup $policyGroup): void
+  {
+    EloquentPolicyGroup::destroy($policyGroup->getId()->toString());
+  }
+
+  public function getPolicies(PolicyGroupId $id): PolicyIdCollection
+  {
+    $eloquentPolicyGroup = EloquentPolicyGroup::find($id->toString());
+    if (!$eloquentPolicyGroup) {
+      return new PolicyIdCollection([]);
+    }
+
+    $policyIds = $eloquentPolicyGroup->policies->map(function (EloquentPolicy $eloquentPolicy) {
+      return new PolicyId($eloquentPolicy->id);
+    })->toArray();
+
+    return new PolicyIdCollection($policyIds);
+  }
+
+  public function addPolicy(PolicyGroupId $groupId, PolicyId $policyId): void
+  {
+    $eloquentPolicyGroup = EloquentPolicyGroup::find($groupId->toString());
+    $eloquentPolicyGroup->policies()->attach($policyId->toString());
+  }
+
+  public function removePolicy(PolicyGroupId $groupId, PolicyId $policyId): void
+  {
+    $eloquentPolicyGroup = EloquentPolicyGroup::find($groupId->toString());
+    $eloquentPolicyGroup->policies()->detach($policyId->toString());
+  }
+
+  private function toDomainEntity(EloquentPolicyGroup $eloquentPolicyGroup): PolicyGroup
+  {
+    $policyIds = $eloquentPolicyGroup->policies->map(function (EloquentPolicy $eloquentPolicy) {
+      return new PolicyId($eloquentPolicy->id);
+    })->toArray();
+
+    return new PolicyGroup(
+      new PolicyGroupId($eloquentPolicyGroup->id),
+      new PolicyGroupName($eloquentPolicyGroup->name),
+      new PolicyGroupDescription($eloquentPolicyGroup->description),
+      new PolicyIdCollection($policyIds)
+    );
+  }
+}

--- a/src/laravel/app/Infrastructure/Persistence/EloquentRoleRepository.php
+++ b/src/laravel/app/Infrastructure/Persistence/EloquentRoleRepository.php
@@ -11,6 +11,8 @@ use App\Domain\ValueObjects\PolicyId;
 use App\Models\EloquentRole;
 use Illuminate\Support\Collection;
 use App\Domain\Repositories\RoleRepositoryInterface;
+use App\Domain\ValueObjects\PolicyGroupId;
+use App\Domain\ValueObjects\PolicyGroupIdCollection;
 
 class EloquentRoleRepository implements RoleRepositoryInterface
 {
@@ -84,11 +86,16 @@ class EloquentRoleRepository implements RoleRepositoryInterface
       return new PolicyId($id);
     })->toArray();
 
+    $policyGroupIds = $eloquentRole->policyGroups->pluck('id')->map(function ($id) {
+      return new PolicyGroupId($id);
+    })->toArray();
+
     return new Role(
       new RoleId($eloquentRole->id),
       new RoleName($eloquentRole->name),
       new RoleDescription($eloquentRole->description),
-      new PolicyIdCollection($policyIds)
+      new PolicyIdCollection($policyIds),
+      new PolicyGroupIdCollection($policyGroupIds)
     );
   }
 }

--- a/src/laravel/app/Models/EloquentPolicy.php
+++ b/src/laravel/app/Models/EloquentPolicy.php
@@ -6,6 +6,7 @@ use App\Domain\ValueObjects\PolicyId;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class EloquentPolicy extends Model
 {
@@ -52,5 +53,21 @@ class EloquentPolicy extends Model
   public function getStatementsAttribute()
   {
     return $this->document['Statement'] ?? [];
+  }
+
+  /**
+   * ポリシーに関連付けられたポリシーグループを取得
+   */
+  public function policyGroups(): BelongsToMany
+  {
+    return $this->belongsToMany(EloquentPolicyGroup::class, 'policy_group_policy', 'policy_id', 'policy_group_id');
+  }
+
+  /**
+   * ポリシーに直接関連付けられたロールを取得
+   */
+  public function roles(): BelongsToMany
+  {
+    return $this->belongsToMany(EloquentRole::class, 'role_policy', 'policy_id', 'role_id');
   }
 }

--- a/src/laravel/app/Models/EloquentPolicyGroup.php
+++ b/src/laravel/app/Models/EloquentPolicyGroup.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Models;
+
+use App\Domain\ValueObjects\PolicyGroupId;
+use App\Domain\ValueObjects\PolicyGroupName;
+use App\Domain\ValueObjects\PolicyGroupDescription;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class EloquentPolicyGroup extends Model
+{
+  use HasFactory, HasUuids;
+
+  protected $table = 'policy_groups';
+
+  protected $fillable = [
+    'id',
+    'name',
+    'description',
+  ];
+
+  /**
+   * IDの自動生成を無効化
+   */
+  public $incrementing = false;
+
+  /**
+   * UUIDの自動生成を無効化
+   */
+  protected static function boot()
+  {
+    parent::boot();
+    static::creating(function ($model) {
+      // IDが設定されていない場合のみUUIDを生成
+      if (empty($model->{$model->getKeyName()})) {
+        $model->{$model->getKeyName()} = (new PolicyGroupId())->toString();
+      }
+    });
+  }
+
+  /**
+   * ポリシーグループに関連付けられたポリシーを取得
+   */
+  public function policies(): BelongsToMany
+  {
+    return $this->belongsToMany(EloquentPolicy::class, 'policy_group_policy', 'policy_group_id', 'policy_id');
+  }
+
+  /**
+   * ポリシーグループに関連付けられたロールを取得
+   */
+  public function roles(): BelongsToMany
+  {
+    return $this->belongsToMany(EloquentRole::class, 'role_policy_group', 'policy_group_id', 'role_id');
+  }
+
+  public function setNameAttribute($value)
+  {
+    $this->attributes['name'] = (new PolicyGroupName($value))->toString();
+  }
+
+  public function setDescriptionAttribute($value)
+  {
+    $this->attributes['description'] = (new PolicyGroupDescription($value))->toString();
+  }
+}

--- a/src/laravel/app/Models/EloquentRole.php
+++ b/src/laravel/app/Models/EloquentRole.php
@@ -47,4 +47,12 @@ class EloquentRole extends Model
   {
     return $this->belongsToMany(EloquentPolicy::class, 'role_policy', 'role_id', 'policy_id');
   }
+
+  /**
+   * ロールに関連付けられたポリシーグループを取得
+   */
+  public function policyGroups(): BelongsToMany
+  {
+    return $this->belongsToMany(EloquentPolicyGroup::class, 'role_policy_group', 'role_id', 'policy_group_id');
+  }
 }

--- a/src/laravel/database/factories/EloquentPolicyGroupFactory.php
+++ b/src/laravel/database/factories/EloquentPolicyGroupFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\EloquentPolicyGroup;
+use App\Domain\ValueObjects\PolicyGroupId;
+use App\Domain\ValueObjects\PolicyGroupName;
+use App\Domain\ValueObjects\PolicyGroupDescription;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class EloquentPolicyGroupFactory extends Factory
+{
+  protected $model = EloquentPolicyGroup::class;
+
+  public function definition(): array
+  {
+    return [
+      'id' => (new PolicyGroupId())->toString(),
+      'name' => (new PolicyGroupName($this->faker->unique()->words(3, true)))->toString(),
+      'description' => (new PolicyGroupDescription($this->faker->sentence()))->toString(),
+    ];
+  }
+
+  /**
+   * ポリシーグループに指定された数のポリシーを関連付ける
+   */
+  public function withPolicies(int $count = 1)
+  {
+    return $this->afterCreating(function (EloquentPolicyGroup $policyGroup) use ($count) {
+      $policyGroup->policies()->attach(
+        \App\Models\EloquentPolicy::factory()->count($count)->create()
+      );
+    });
+  }
+
+  /**
+   * ポリシーグループに指定された数のロールを関連付ける
+   */
+  public function withRoles(int $count = 1)
+  {
+    return $this->afterCreating(function (EloquentPolicyGroup $policyGroup) use ($count) {
+      $policyGroup->roles()->attach(
+        \App\Models\EloquentRole::factory()->count($count)->create()
+      );
+    });
+  }
+}

--- a/src/laravel/database/migrations/2024_09_10_000003_create_policy_groups_table.php
+++ b/src/laravel/database/migrations/2024_09_10_000003_create_policy_groups_table.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePolicyGroupsTable extends Migration
+{
+  public function up()
+  {
+    Schema::create('policy_groups', function (Blueprint $table) {
+      $table->uuid('id')->primary();
+      $table->string('name')->unique();
+      $table->text('description');
+      $table->timestamps();
+
+      // 名前に対するインデックスを追加
+      $table->index('name');
+    });
+
+    Schema::create('policy_group_policy', function (Blueprint $table) {
+      $table->uuid('policy_group_id');
+      $table->uuid('policy_id');
+
+      $table->foreign('policy_group_id')->references('id')->on('policy_groups')->onDelete('cascade');
+      $table->foreign('policy_id')->references('id')->on('policies')->onDelete('cascade');
+
+      // 複合主キー
+      $table->primary(['policy_group_id', 'policy_id']);
+
+      // それぞれのIDに対するインデックスを追加
+      $table->index('policy_group_id');
+      $table->index('policy_id');
+    });
+
+    Schema::create('role_policy_group', function (Blueprint $table) {
+      $table->uuid('role_id');
+      $table->uuid('policy_group_id');
+
+      $table->foreign('role_id')->references('id')->on('roles')->onDelete('cascade');
+      $table->foreign('policy_group_id')->references('id')->on('policy_groups')->onDelete('cascade');
+
+      // 複合主キー
+      $table->primary(['role_id', 'policy_group_id']);
+
+      // それぞれのIDに対するインデックスを追加
+      $table->index('role_id');
+      $table->index('policy_group_id');
+    });
+  }
+
+  public function down()
+  {
+    Schema::dropIfExists('role_policy_group');
+    Schema::dropIfExists('policy_group_policy');
+    Schema::dropIfExists('policy_groups');
+  }
+}

--- a/src/laravel/tests/Feature/Application/Services/GetUserDetailsByNameServiceTest.php
+++ b/src/laravel/tests/Feature/Application/Services/GetUserDetailsByNameServiceTest.php
@@ -10,10 +10,13 @@ use App\Models\User as EloquentUser;
 use App\Domain\ValueObjects\Username;
 use App\Infrastructure\Persistence\EloquentUserProfileRepository;
 use App\Infrastructure\Persistence\EloquentUserRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class GetUserDetailsByNameServiceTest extends TestCase
 {
+  use RefreshDatabase;
+
   /** @test */
   public function testExistsUser()
   {

--- a/src/laravel/tests/Feature/Application/Services/GetUserDetailsByUserIdServiceTest.php
+++ b/src/laravel/tests/Feature/Application/Services/GetUserDetailsByUserIdServiceTest.php
@@ -10,10 +10,13 @@ use App\Models\User as EloquentUser;
 use App\Domain\ValueObjects\UserId;
 use App\Infrastructure\Persistence\EloquentUserProfileRepository;
 use App\Infrastructure\Persistence\EloquentUserRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class GetUserDetailsByUserIdServiceTest extends TestCase
 {
+  use RefreshDatabase;
+
   /** @test */
   public function testExistsUser()
   {

--- a/src/laravel/tests/Feature/Application/UseeCases/FindUserByNameUseCaseTest.php
+++ b/src/laravel/tests/Feature/Application/UseeCases/FindUserByNameUseCaseTest.php
@@ -7,10 +7,12 @@ use App\Models\User as EloquentUser;
 use App\Domain\Entities\User;
 use App\Domain\ValueObjects\Username;
 use App\Infrastructure\Persistence\EloquentUserRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class FindUserByNameUseCaseTest extends TestCase
 {
+  use RefreshDatabase;
   private FindUserByNameUseCase $findUserByNameUseCase;
 
   protected function setUp(): void
@@ -25,7 +27,7 @@ class FindUserByNameUseCaseTest extends TestCase
     $user = EloquentUser::factory()->create();
 
     // When
-    $result =$this->findUserByNameUseCase->execute(new Username($user->name));
+    $result = $this->findUserByNameUseCase->execute(new Username($user->name));
 
     // Then
     $this->assertInstanceOf(User::class, $result);

--- a/src/laravel/tests/Feature/Infrastructure/Persistence/EloquentPolicyGroupRepositoryTest.php
+++ b/src/laravel/tests/Feature/Infrastructure/Persistence/EloquentPolicyGroupRepositoryTest.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Tests\Feature\Infrastructure\Persistence;
+
+use App\Domain\Entities\PolicyGroup;
+use App\Domain\ValueObjects\PolicyGroupId;
+use App\Domain\ValueObjects\PolicyGroupName;
+use App\Domain\ValueObjects\PolicyGroupDescription;
+use App\Domain\ValueObjects\PolicyGroupIdCollection;
+use App\Domain\ValueObjects\PolicyId;
+use App\Domain\ValueObjects\PolicyIdCollection;
+use App\Infrastructure\Persistence\EloquentPolicyGroupRepository;
+use App\Models\EloquentPolicyGroup;
+use App\Models\EloquentPolicy;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EloquentPolicyGroupRepositoryTest extends TestCase
+{
+  use RefreshDatabase;
+
+  private EloquentPolicyGroupRepository $repository;
+
+  protected function setUp(): void
+  {
+    parent::setUp();
+    $this->repository = new EloquentPolicyGroupRepository();
+  }
+
+  public function test_all(): void
+  {
+    // Given
+    EloquentPolicyGroup::factory()->count(3)->create();
+
+    // When
+    $policyGroups = $this->repository->all();
+
+    // Then
+    $this->assertCount(3, $policyGroups->toArray());
+    $this->assertInstanceOf(PolicyGroupIdCollection::class, $policyGroups);
+    foreach ($policyGroups as $policyGroupId) {
+      $this->assertInstanceOf(PolicyGroupId::class, $policyGroupId);
+    }
+  }
+
+  public function test_findById(): void
+  {
+    // Given
+    $createdPolicyGroup = EloquentPolicyGroup::factory()->create();
+
+    // When
+    $policyGroup = $this->repository->findById(new PolicyGroupId($createdPolicyGroup->id));
+
+    // Then
+    $this->assertNotNull($policyGroup);
+    $this->assertEquals($createdPolicyGroup->name, $policyGroup->getName()->toString());
+    $this->assertEquals($createdPolicyGroup->description, $policyGroup->getDescription()->toString());
+  }
+
+  public function test_findByName(): void
+  {
+    // Given
+    $createdPolicyGroup = EloquentPolicyGroup::factory()->create();
+
+    // When
+    $policyGroup = $this->repository->findByName(new PolicyGroupName($createdPolicyGroup->name));
+
+    // Then
+    $this->assertNotNull($policyGroup);
+    $this->assertEquals($createdPolicyGroup->id, $policyGroup->getId()->toString());
+  }
+
+  public function test_save_create_new(): void
+  {
+    // Given
+    $newPolicyGroup = new PolicyGroup(
+      new PolicyGroupId(),
+      new PolicyGroupName('New PolicyGroup'),
+      new PolicyGroupDescription('New Description'),
+      new PolicyIdCollection([])
+    );
+
+    // When
+    $this->repository->save($newPolicyGroup);
+
+    // Then
+    $policyGroupFromDatabase = EloquentPolicyGroup::find($newPolicyGroup->getId()->toString());
+
+    $this->assertNotNull($policyGroupFromDatabase);
+    $this->assertEquals($newPolicyGroup->getName()->toString(), $policyGroupFromDatabase->name);
+    $this->assertEquals($newPolicyGroup->getDescription()->toString(), $policyGroupFromDatabase->description);
+
+    // PolicyIdCollection と EloquentPolicyGroup のポリシーを比較
+    $this->assertCount(0, $policyGroupFromDatabase->policies);
+    $this->assertEquals(
+      $newPolicyGroup->getPolicies()->toArray(),
+      $policyGroupFromDatabase->policies->pluck('id')->toArray()
+    );
+  }
+
+  public function test_save_update_existing(): void
+  {
+    // Given
+    $existingPolicyGroup = EloquentPolicyGroup::factory()->create();
+    $policy = EloquentPolicy::factory()->create();
+    $existingPolicyGroup->policies()->attach($policy);
+
+    // When
+    $updatedPolicyGroup = new PolicyGroup(
+      new PolicyGroupId($existingPolicyGroup->id),
+      new PolicyGroupName('Updated Name'),
+      new PolicyGroupDescription('Updated Description'),
+      new PolicyIdCollection([new PolicyId($policy->id)])
+    );
+
+    $this->repository->save($updatedPolicyGroup);
+
+    // Then
+    $policyGroupFromDatabase = EloquentPolicyGroup::find($existingPolicyGroup->id);
+
+    $this->assertNotNull($policyGroupFromDatabase);
+    $this->assertEquals($updatedPolicyGroup->getName()->toString(), $policyGroupFromDatabase->name);
+    $this->assertEquals($updatedPolicyGroup->getDescription()->toString(), $policyGroupFromDatabase->description);
+
+    // PolicyIdCollection と EloquentPolicyGroup のポリシーを比較
+    $this->assertCount(1, $policyGroupFromDatabase->policies);
+    $this->assertEquals(
+      $updatedPolicyGroup->getPolicies()->toArray(),
+      $policyGroupFromDatabase->policies->pluck('id')->map(fn($id) => new PolicyId($id))->toArray()
+    );
+
+    // 更新前と更新後で、名前と説明が変更されていることを確認
+    $this->assertNotEquals($existingPolicyGroup->name, $policyGroupFromDatabase->name);
+    $this->assertNotEquals($existingPolicyGroup->description, $policyGroupFromDatabase->description);
+  }
+
+  public function test_delete(): void
+  {
+    // Given
+    $policyGroupToDelete = EloquentPolicyGroup::factory()->create();
+
+    // When
+    $policyGroup = $this->repository->findById(new PolicyGroupId($policyGroupToDelete->id));
+    $this->assertNotNull($policyGroup);
+
+    $this->repository->delete($policyGroup);
+
+    // Then
+    $this->assertDatabaseMissing('policy_groups', [
+      'id' => $policyGroupToDelete->id
+    ]);
+  }
+
+  public function test_getPolicies(): void
+  {
+    // Given
+    $policyGroup = EloquentPolicyGroup::factory()->create();
+    $policies = EloquentPolicy::factory()->count(3)->create();
+    $policyGroup->policies()->attach($policies->pluck('id'));
+
+    // When
+    $policyIds = $this->repository->getPolicies(new PolicyGroupId($policyGroup->id));
+
+    // Then
+    $this->assertCount(3, $policyIds->toArray());
+    $this->assertInstanceOf(PolicyIdCollection::class, $policyIds);
+    foreach ($policyIds as $policyId) {
+      $this->assertInstanceOf(PolicyId::class, $policyId);
+      $this->assertTrue($policies->pluck('id')->contains($policyId->toString()));
+    }
+  }
+
+  public function test_addPolicy(): void
+  {
+    // Given
+    $policyGroup = EloquentPolicyGroup::factory()->create();
+    $policy = EloquentPolicy::factory()->create();
+
+    // When
+    $this->repository->addPolicy(new PolicyGroupId($policyGroup->id), new PolicyId($policy->id));
+
+    // Then
+    $this->assertDatabaseHas('policy_group_policy', [
+      'policy_group_id' => $policyGroup->id,
+      'policy_id' => $policy->id
+    ]);
+  }
+
+  public function test_removePolicy(): void
+  {
+    // Given
+    $policyGroup = EloquentPolicyGroup::factory()->create();
+    $policy = EloquentPolicy::factory()->create();
+    $policyGroup->policies()->attach($policy->id);
+
+    // When
+    $this->repository->removePolicy(new PolicyGroupId($policyGroup->id), new PolicyId($policy->id));
+
+    // Then
+    $this->assertDatabaseMissing('policy_group_policy', [
+      'policy_group_id' => $policyGroup->id,
+      'policy_id' => $policy->id
+    ]);
+  }
+}

--- a/src/laravel/tests/Feature/Infrastructure/Persistence/EloquentRoleRepositoryTest.php
+++ b/src/laravel/tests/Feature/Infrastructure/Persistence/EloquentRoleRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Infrastructure\Persistence;
 
 use App\Domain\Entities\Role;
+use App\Domain\ValueObjects\PolicyGroupIdCollection;
 use App\Domain\ValueObjects\RoleId;
 use App\Domain\ValueObjects\RoleName;
 use App\Domain\ValueObjects\RoleDescription;
@@ -73,7 +74,8 @@ class EloquentRoleRepositoryTest extends TestCase
       new RoleId(),
       new RoleName('New Role'),
       new RoleDescription('New Description'),
-      new PolicyIdCollection([])
+      new PolicyIdCollection([]),
+      new PolicyGroupIdCollection([]),
     );
 
     // When
@@ -85,7 +87,22 @@ class EloquentRoleRepositoryTest extends TestCase
     $this->assertNotNull($roleFromDatabase);
     $this->assertEquals($newRole->getName()->toString(), $roleFromDatabase->name);
     $this->assertEquals($newRole->getDescription()->toString(), $roleFromDatabase->description);
+
+    // PolicyIdCollection と EloquentRole のポリシーを比較
+    $this->assertCount(0, $roleFromDatabase->policies);
+    $this->assertEquals(
+      $newRole->getPolicies()->toArray(),
+      $roleFromDatabase->policies->pluck('id')->toArray()
+    );
+
+    // PolicyGroupIdCollection と EloquentRole のポリシーグループを比較
+    $this->assertCount(0, $roleFromDatabase->policyGroups);
+    $this->assertEquals(
+      $newRole->getPolicyGroups()->toArray(),
+      $roleFromDatabase->policyGroups->pluck('id')->toArray()
+    );
   }
+
 
   public function test_save_update_existing(): void
   {
@@ -97,7 +114,8 @@ class EloquentRoleRepositoryTest extends TestCase
       new RoleId($existingRole->id),
       new RoleName('Updated Name'),
       new RoleDescription('Updated Description'),
-      new PolicyIdCollection([])
+      new PolicyIdCollection([]),
+      new PolicyGroupIdCollection([]),
     );
 
     $this->repository->save($updatedRole);
@@ -108,6 +126,24 @@ class EloquentRoleRepositoryTest extends TestCase
     $this->assertNotNull($roleFromDatabase);
     $this->assertEquals($updatedRole->getName()->toString(), $roleFromDatabase->name);
     $this->assertEquals($updatedRole->getDescription()->toString(), $roleFromDatabase->description);
+
+    // PolicyIdCollection と EloquentRole のポリシーを比較
+    $this->assertCount(0, $roleFromDatabase->policies);
+    $this->assertEquals(
+      $updatedRole->getPolicies()->toArray(),
+      $roleFromDatabase->policies->pluck('id')->toArray()
+    );
+
+    // PolicyGroupIdCollection と EloquentRole のポリシーグループを比較
+    $this->assertCount(0, $roleFromDatabase->policyGroups);
+    $this->assertEquals(
+      $updatedRole->getPolicyGroups()->toArray(),
+      $roleFromDatabase->policyGroups->pluck('id')->toArray()
+    );
+
+    // 更新前と更新後で、名前と説明が変更されていることを確認
+    $this->assertNotEquals($existingRole->name, $roleFromDatabase->name);
+    $this->assertNotEquals($existingRole->description, $roleFromDatabase->description);
   }
 
   public function test_delete(): void

--- a/src/laravel/tests/Feature/Infrastructure/Persistence/EloquentUserRepositoryTest.php
+++ b/src/laravel/tests/Feature/Infrastructure/Persistence/EloquentUserRepositoryTest.php
@@ -26,6 +26,7 @@ class EloquentUserRepositoryTest extends TestCase
     parent::setUp();
     $this->repository = new EloquentUserRepository();
     config(['app.timezone' => 'Asia/Tokyo']);
+    config()->set('logging.default', 'stderr'); 
   }
 
   public function test_all(): void
@@ -35,6 +36,7 @@ class EloquentUserRepositoryTest extends TestCase
 
     // When
     $users = $this->repository->all();
+    dump($users);
 
     // Then
     $this->assertCount(3, $users);

--- a/src/laravel/tests/Unit/Domain/Entities/PolicyGroupTest.php
+++ b/src/laravel/tests/Unit/Domain/Entities/PolicyGroupTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Unit\Domain\Entities;
+
+use App\Domain\Entities\PolicyGroup;
+use App\Domain\ValueObjects\PolicyGroupDescription;
+use App\Domain\ValueObjects\PolicyGroupId;
+use App\Domain\ValueObjects\PolicyGroupName;
+use App\Domain\ValueObjects\PolicyId;
+use App\Domain\ValueObjects\PolicyIdCollection;
+use Tests\TestCase;
+
+class PolicyGroupTest extends TestCase
+{
+  /** @test */
+  public function testCreateInstance()
+  {
+    // Given
+    $policyGroupId = new PolicyGroupId();
+    $policyGroupName = new PolicyGroupName('テストポリシーグループ');
+    $policyGroupDescription = new PolicyGroupDescription('簡単な説明');
+    $policyId_1 = new PolicyId();
+    $policyId_2 = new PolicyId();
+    $policies = new PolicyIdCollection([$policyId_1, $policyId_2]);
+
+    // When
+    $policyGroup = new PolicyGroup($policyGroupId, $policyGroupName, $policyGroupDescription, $policies);
+
+    // Then
+    $this->assertInstanceOf(PolicyGroup::class, $policyGroup);
+    $this->assertEquals($policyGroupId, $policyGroup->getId());
+    $this->assertEquals($policyGroupName, $policyGroup->getName());
+    $this->assertEquals($policies, $policyGroup->getPolicies());
+  }
+}
+

--- a/src/laravel/tests/Unit/Domain/Entities/PolicyGroupTest.php
+++ b/src/laravel/tests/Unit/Domain/Entities/PolicyGroupTest.php
@@ -32,5 +32,48 @@ class PolicyGroupTest extends TestCase
     $this->assertEquals($policyGroupName, $policyGroup->getName());
     $this->assertEquals($policies, $policyGroup->getPolicies());
   }
-}
 
+  /** @test */
+  public function testAddPolicy()
+  {
+    // Given
+    $policyGroupId = new PolicyGroupId();
+    $policyGroupName = new PolicyGroupName('テストポリシーグループ');
+    $policyGroupDescription = new PolicyGroupDescription('簡単な説明');
+    $policyId_1 = new PolicyId();
+    $policyId_2 = new PolicyId();
+    $policies = new PolicyIdCollection([$policyId_1]);
+
+    // When
+    $policyGroup = new PolicyGroup($policyGroupId, $policyGroupName, $policyGroupDescription, $policies);
+    $policyGroup->addPolicy($policyId_2);
+
+    // Then
+    $this->assertInstanceOf(PolicyGroup::class, $policyGroup);
+    $this->assertEquals($policyGroupId, $policyGroup->getId());
+    $this->assertEquals($policyGroupName, $policyGroup->getName());
+    $this->assertCount(2, $policyGroup->getPolicies()->toArray());
+  }
+
+  /** @test */
+  public function testRemovePolicy()
+  {
+    // Given
+    $policyGroupId = new PolicyGroupId();
+    $policyGroupName = new PolicyGroupName('テストポリシーグループ');
+    $policyGroupDescription = new PolicyGroupDescription('簡単な説明');
+    $policyId_1 = new PolicyId();
+    $policyId_2 = new PolicyId();
+    $policies = new PolicyIdCollection([$policyId_1, $policyId_2]);
+
+    // When
+    $policyGroup = new PolicyGroup($policyGroupId, $policyGroupName, $policyGroupDescription, $policies);
+    $policyGroup->removePolicy($policyId_2);
+
+    // Then
+    $this->assertInstanceOf(PolicyGroup::class, $policyGroup);
+    $this->assertEquals($policyGroupId, $policyGroup->getId());
+    $this->assertEquals($policyGroupName, $policyGroup->getName());
+    $this->assertCount(1, $policyGroup->getPolicies()->toArray());
+  }
+}

--- a/src/laravel/tests/Unit/Domain/Entities/PolicyTest.php
+++ b/src/laravel/tests/Unit/Domain/Entities/PolicyTest.php
@@ -18,7 +18,7 @@ class PolicyTest extends TestCase
     $policyId = new PolicyId();
     $policyName = new PolicyName('テストポリシー名');
     $policyDescription = new PolicyDescription('テストポリシーの説明');
-    $policyDocument = new PolicyDocument('{"statement": "example"}');
+    $policyDocument = new PolicyDocument(['Statement' => 'sample']);
 
     // When
     $policy = new Policy(

--- a/src/laravel/tests/Unit/Domain/Entities/RoleTest.php
+++ b/src/laravel/tests/Unit/Domain/Entities/RoleTest.php
@@ -8,6 +8,8 @@ use App\Domain\ValueObjects\RoleId;
 use App\Domain\ValueObjects\RoleName;
 use Tests\TestCase;
 use App\Domain\Entities\Role;
+use App\Domain\ValueObjects\PolicyGroupId;
+use App\Domain\ValueObjects\PolicyGroupIdCollection;
 use App\Domain\ValueObjects\PolicyIdCollection;
 
 class RoleTest extends TestCase
@@ -20,9 +22,10 @@ class RoleTest extends TestCase
     $roleName = new RoleName('テストロール');
     $roleDescription = new RoleDescription('テスト用の説明');
     $policyIdCollection = new PolicyIdCollection([new PolicyId(), new PolicyId()]);
+    $policyGroupIdCollection = new PolicyGroupIdCollection([new PolicyGroupId(), new PolicyGroupId()]);
 
     // When
-    $role = new Role($roleId, $roleName, $roleDescription, $policyIdCollection);
+    $role = new Role($roleId, $roleName, $roleDescription, $policyIdCollection, $policyGroupIdCollection);
 
     // Then
     $this->assertInstanceOf(Role::class, $role);
@@ -30,5 +33,6 @@ class RoleTest extends TestCase
     $this->assertEquals($roleName, $role->getName());
     $this->assertEquals($roleDescription, $role->getDescription());
     $this->assertEquals($policyIdCollection, $role->getPolicies());
+    $this->assertEquals($policyGroupIdCollection, $role->getPolicyGroups());
   }
 }

--- a/src/laravel/tests/Unit/Domain/ValueObjects/PolicyGroupDescriptionTest.php
+++ b/src/laravel/tests/Unit/Domain/ValueObjects/PolicyGroupDescriptionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Unit\Domain\ValueObjects;
+
+use App\Domain\ValueObjects\PolicyGroupDescription;
+use Tests\TestCase;
+
+class PolicyGroupDescriptionTest extends TestCase
+{
+  /**
+   * @test
+   */
+  public function testCreateInstance(): void
+  {
+    // Given
+    $policyGroupDescription = 'This is a policy description.';
+
+    // When
+    $policyGroupDescriptionValueObject = new PolicyGroupDescription($policyGroupDescription);
+
+    // Then
+    $this->assertInstanceOf(PolicyGroupDescription::class, $policyGroupDescriptionValueObject);
+  }
+
+  /**
+   * @test
+   */
+  public function testToString(): void
+  {
+    // Given
+    $policyGroupDescription = 'This is a policy description.';
+
+    // When
+    $policyGroupDescriptionValueObject = new PolicyGroupDescription($policyGroupDescription);
+
+    // Then
+    $this->assertEquals($policyGroupDescription, $policyGroupDescriptionValueObject->toString());
+  }
+
+  /**
+   * @test
+   */
+  public function testValidLength(): void
+  {
+    // Given
+    $policyGroupDescription = str_repeat('a', 255);
+
+    // When
+    $policyGroupDescriptionValueObject = new PolicyGroupDescription($policyGroupDescription);
+
+    // Then
+    $this->assertInstanceOf(PolicyGroupDescription::class, $policyGroupDescriptionValueObject);
+  }
+
+  /**
+   * @test
+   */
+  public function testInvalidLength(): void
+  {
+    // Given
+    $policyGroupDescription = str_repeat('a', 256);
+
+    // When & Then
+    $this->expectException(\InvalidArgumentException::class);
+    new PolicyGroupDescription($policyGroupDescription);
+  }
+}

--- a/src/laravel/tests/Unit/Domain/ValueObjects/PolicyGroupIdCollectionTest.php
+++ b/src/laravel/tests/Unit/Domain/ValueObjects/PolicyGroupIdCollectionTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tests\Unit\Domain\ValueObjects;
+
+use App\Domain\ValueObjects\PolicyGroupId;
+use App\Domain\ValueObjects\PolicyGroupIdCollection;
+use Tests\TestCase;
+
+class PolicyGroupIdCollectionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function testCreatePolicyGroupIdCollectionWithValidData()
+    {
+        // Given
+        $policyGroupId1 = new PolicyGroupId();
+        $policyGroupId2 = new PolicyGroupId();
+
+        // When
+        $policyGroupIdCollection = new PolicyGroupIdCollection([$policyGroupId1, $policyGroupId2]);
+
+        // Then
+        $this->assertInstanceOf(PolicyGroupIdCollection::class, $policyGroupIdCollection);
+        $this->assertCount(2, $policyGroupIdCollection->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function testCreatePolicyGroupIdCollectionWithInvalidData()
+    {
+        // Given
+        $policyGroupId1 = "invalid policy id";
+
+        // Then
+        $this->expectException(\InvalidArgumentException::class);
+
+        // When
+        new PolicyGroupIdCollection([$policyGroupId1]);
+    }
+
+    /**
+     * @test
+     */
+    public function testToArray()
+    {
+        // Given
+        $policyGroupId1 = new PolicyGroupId();
+        $policyGroupId2 = new PolicyGroupId();
+        $policyGroupIdCollection = new PolicyGroupIdCollection([$policyGroupId1, $policyGroupId2]);
+
+        // When
+        $result = $policyGroupIdCollection->toArray();
+
+        // Then
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        $this->assertContainsOnlyInstancesOf(PolicyGroupId::class, $result);
+    }
+
+    /**
+     * @test
+     */
+    public function testAdd()
+    {
+        // Given
+        $policyGroupId1 = new PolicyGroupId();
+        $policyGroupId2 = new PolicyGroupId();
+        $policyGroupIdCollection = new PolicyGroupIdCollection([$policyGroupId1]);
+
+        // When
+        $newPolicyGroupIdCollection = $policyGroupIdCollection->add($policyGroupId2);
+
+        // Then
+        $this->assertNotSame($policyGroupIdCollection, $newPolicyGroupIdCollection);
+        $this->assertCount(1, $policyGroupIdCollection->toArray());
+        $this->assertCount(2, $newPolicyGroupIdCollection->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function testRemove()
+    {
+        // Given
+        $policyGroupId1 = new PolicyGroupId();
+        $policyGroupId2 = new PolicyGroupId();
+        $policyGroupIdCollection = new PolicyGroupIdCollection([$policyGroupId1, $policyGroupId2]);
+
+        // When
+        $newPolicyGroupIdCollection = $policyGroupIdCollection->remove($policyGroupId2);
+
+        // Then
+        $this->assertNotSame($policyGroupIdCollection, $newPolicyGroupIdCollection);
+        $this->assertCount(2, $policyGroupIdCollection->toArray());
+        $this->assertCount(1, $newPolicyGroupIdCollection->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function testContains()
+    {
+        // Given
+        $policyGroupId1 = new PolicyGroupId();
+        $policyGroupId2 = new PolicyGroupId();
+        $policyGroupIdCollection = new PolicyGroupIdCollection([$policyGroupId1]);
+
+        // When
+        $result1 = $policyGroupIdCollection->contains($policyGroupId1);
+        $result2 = $policyGroupIdCollection->contains($policyGroupId2);
+
+        // Then
+        $this->assertTrue($result1);
+        $this->assertFalse($result2);
+    }
+
+    /**
+     * @test
+     */
+    public function testCount()
+    {
+        // Given
+        $policyGroupId1 = new PolicyGroupId();
+        $policyGroupId2 = new PolicyGroupId();
+        $policyGroupIdCollection = new PolicyGroupIdCollection([$policyGroupId1, $policyGroupId2]);
+
+        // When
+        $result = $policyGroupIdCollection->count();
+
+        // Then
+        $this->assertEquals(2, $result);
+    }
+}

--- a/src/laravel/tests/Unit/Domain/ValueObjects/PolicyGroupIdTest.php
+++ b/src/laravel/tests/Unit/Domain/ValueObjects/PolicyGroupIdTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Unit\Domain\ValueObjects;
+
+use App\Domain\ValueObjects\PolicyGroupId;
+use Tests\TestCase;
+use Ramsey\Uuid\Uuid;
+
+class PolicyGroupIdTest extends TestCase
+{
+  const CORRECT_PREFIX = "policyGp";
+  protected function setUp(): void
+  {
+    parent::setUp();
+    config()->set('logging.default', 'stderr'); 
+  }
+
+  /**
+   * @test
+   */
+  public function testToString(): void
+  {
+    // Given
+    $policyGroupId = self::CORRECT_PREFIX . substr(Uuid::uuid4()->toString(), 8);
+
+    // When
+    $policyGroupIdValueObject = new PolicyGroupId($policyGroupId);
+
+    // Then
+    $this->assertEquals($policyGroupId, $policyGroupIdValueObject->toString());
+  }
+
+  /**
+   * @test
+   */
+  public function testInvalidPolicyGroupIdFormat(): void
+  {
+    // Given
+    $policyGroupId = "user0000-invalid-user-id-format";
+
+    // When & Then
+    $this->expectException(\InvalidArgumentException::class);
+    new PolicyGroupId($policyGroupId);
+  }
+
+  /**
+   * @test
+   */
+  public function testInvalidPolicyGroupIdPrefix(): void
+  {
+    // Given
+    $policyGroupId = Uuid::uuid4()->toString();
+
+    // When & Then
+    $this->expectException(\InvalidArgumentException::class);
+    new PolicyGroupId($policyGroupId);
+  }
+
+  /**
+   * @test
+   */
+  public function testInvalidPolicyGroupIdUuidVersion(): void
+  {
+    // Given
+    $policyGroupId = self::CORRECT_PREFIX . Uuid::uuid3(Uuid::NAMESPACE_URL, 'example.com')->toString();
+
+    // When & Then
+    $this->expectException(\InvalidArgumentException::class);
+    new PolicyGroupId($policyGroupId);
+  }
+
+  /**
+   * @test
+   */
+  public function testGenerateNewIdWhenNoArgument(): void
+  {
+    // Given & When
+    $policyGroupIdValueObject = new PolicyGroupId();
+
+    // Then
+    $this->assertStringStartsWith(self::CORRECT_PREFIX, $policyGroupIdValueObject->toString());
+  }
+
+
+  /**
+   * @test
+   */
+  public function testCanUpdate(): void
+  {
+    // Given
+    $policyGroupId = new PolicyGroupId();
+    $otherPolicyGroupId = new PolicyGroupId();
+
+    // When & Then
+    $this->assertTrue($policyGroupId->equals($policyGroupId));
+    $this->assertFalse($policyGroupId->equals($otherPolicyGroupId));
+  }
+}

--- a/src/laravel/tests/Unit/Domain/ValueObjects/PolicyGroupNameTest.php
+++ b/src/laravel/tests/Unit/Domain/ValueObjects/PolicyGroupNameTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Unit\Domain\ValueObjects;
+
+use App\Domain\ValueObjects\PolicyGroupName;
+use Tests\TestCase;
+
+class PolicyGroupNameTest extends TestCase
+{
+  /** @test */
+  public function testCreateInstance()
+  {
+    // Given
+    $policyGroupNameString = 'テストポリシー名';
+
+    // When
+    $policyGroupName = new PolicyGroupName($policyGroupNameString);
+
+    // Then
+    $this->assertInstanceOf(PolicyGroupName::class, $policyGroupName);
+  }
+
+  /** @test */
+  public function testToString()
+  {
+    // Given
+    $policyGroupNameString = 'テストポリシー名';
+    $policyGroupName = new PolicyGroupName($policyGroupNameString);
+
+    // When
+    $result = $policyGroupName->toString();
+
+    // Then
+    $this->assertEquals($policyGroupNameString, $result);
+  }
+
+
+  /** @test */
+  public function testValidate()
+  {
+    // 0文字
+    $this->expectException(\InvalidArgumentException::class);
+    new PolicyGroupName('');
+
+    // 1文字
+    $policyGroupName = new PolicyGroupName('a');
+    $this->assertInstanceOf(PolicyGroupName::class, $policyGroupName);
+
+    // 50文字
+    $policyGroupName = new PolicyGroupName(str_repeat('a', 50));
+    $this->assertInstanceOf(PolicyGroupName::class, $policyGroupName);
+
+    // 51文字
+    $this->expectException(\InvalidArgumentException::class);
+    new PolicyGroupName(str_repeat('a', 51));
+  }
+}


### PR DESCRIPTION
## 実施タスク
[対象のissue] : <!-- ここを置き換える -->　#272 

## 実施内容
<!-- 作成内容・何を変更したか -->
<!-- 過去形で箇条書きで記載する -->

<!-- 例： -->
<!-- - 管理画面の作成を行いました -->
<!-- - 管理画面周りのUIテストコードを追加しました -->
- ポリシーグループを作成することで、ポリシーをまとめて管理ができるように変更した
- 一部テストのエラーがあったため、ブランチ違いではあるが急遽修正を行っている
## レビューしてほしいこと
<!-- 実装した箇所の明示 -->
<!-- 全体としてコードについてよりかは実装結果・内容について聞く -->
### 実装した箇所
<!-- 変更したURLパス・対象の画像 -->

<!-- 例： -->
<!-- 変更したURLパス -->

<!-- 【変更前の対象の画像】 -->
<!-- 画像パス -->

<!-- 【変更後の対象の画像】 -->
<!-- 画像パス -->

### 重点的にレビューしてほしいこと
<!-- **レビューしてほしい内容：** -->
<!-- 箇条書きでレビュー方法を記載する -->

<!-- 例 -->
<!-- テストケースに過不足がないこと -->

## 備考
<!-- 実装できていない点・不安・今後の予定などを記載する -->

<!-- 例 -->
<!-- - 管理画面で表示するモーダルについては、別PRで実装を行います -->

