### PR TITLE
271 プロフィールとuserに関するポリシーをシードで作成が可能にする

### DIFF
--- a/src/laravel/database/factories/EloquentRoleFactory.php
+++ b/src/laravel/database/factories/EloquentRoleFactory.php
@@ -7,6 +7,7 @@ use App\Models\EloquentRole;
 use App\Domain\ValueObjects\RoleId;
 use App\Domain\ValueObjects\RoleName;
 use App\Models\EloquentPolicy;
+use App\Models\EloquentPolicyGroup;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class EloquentRoleFactory extends Factory
@@ -40,6 +41,27 @@ class EloquentRoleFactory extends Factory
   {
     return $this->afterCreating(function (EloquentRole $role) use ($policyIds) {
       $role->policies()->attach($policyIds);
+    });
+  }
+
+  /**
+   * ロールに指定した数のポリシーグループを関連付ける
+   */
+  public function withPolicyGroups(int $count = 1)
+  {
+    return $this->afterCreating(function (EloquentRole $role) use ($count) {
+      $policyGroups = EloquentPolicyGroup::factory()->count($count)->create();
+      $role->policyGroups()->attach($policyGroups);
+    });
+  }
+
+  /**
+   * ロールに既存のポリシーグループを関連付ける
+   */
+  public function withExistingPolicyGroups(array $policyGroupIds)
+  {
+    return $this->afterCreating(function (EloquentRole $role) use ($policyGroupIds) {
+      $role->policyGroups()->attach($policyGroupIds);
     });
   }
 }

--- a/src/laravel/database/seeders/DatabaseSeeder.php
+++ b/src/laravel/database/seeders/DatabaseSeeder.php
@@ -19,5 +19,6 @@ class DatabaseSeeder extends Seeder
         //     'email' => 'test@example.com',
         // ]);
         $this->call(SystemUserSeeder::class);
+        $this->call(UserPolicySeeder::class);
     }
 }

--- a/src/laravel/database/seeders/DatabaseSeeder.php
+++ b/src/laravel/database/seeders/DatabaseSeeder.php
@@ -7,18 +7,19 @@ use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
 {
-    /**
-     * Seed the application's database.
-     */
-    public function run(): void
-    {
-        // \App\Models\User::factory(10)->create();
+  /**
+   * Seed the application's database.
+   */
+  public function run(): void
+  {
+    // \App\Models\User::factory(10)->create();
 
-        // \App\Models\User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
-        $this->call(SystemUserSeeder::class);
-        $this->call(UserPolicySeeder::class);
-    }
+    // \App\Models\User::factory()->create([
+    //     'name' => 'Test User',
+    //     'email' => 'test@example.com',
+    // ]);
+    $this->call(SystemUserSeeder::class);
+    $this->call(UserPolicySeeder::class);
+    $this->call(UserPolicyGroupSeeder::class);
+  }
 }

--- a/src/laravel/database/seeders/DatabaseSeeder.php
+++ b/src/laravel/database/seeders/DatabaseSeeder.php
@@ -21,5 +21,6 @@ class DatabaseSeeder extends Seeder
     $this->call(SystemUserSeeder::class);
     $this->call(UserPolicySeeder::class);
     $this->call(UserPolicyGroupSeeder::class);
+    $this->call(UserRolePolicyGroupSeeder::class);
   }
 }

--- a/src/laravel/database/seeders/DatabaseSeeder.php
+++ b/src/laravel/database/seeders/DatabaseSeeder.php
@@ -22,5 +22,6 @@ class DatabaseSeeder extends Seeder
     $this->call(UserPolicySeeder::class);
     $this->call(UserPolicyGroupSeeder::class);
     $this->call(UserRolePolicyGroupSeeder::class);
+    $this->call(RootAdminSeeder::class);
   }
 }

--- a/src/laravel/database/seeders/RootAdminSeeder.php
+++ b/src/laravel/database/seeders/RootAdminSeeder.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Domain\ValueObjects\UserId;
+use Illuminate\Database\Seeder;
+use App\Models\User;
+use App\Models\EloquentRole;
+use App\Models\EloquentUserRole;
+use Illuminate\Support\Facades\Hash;
+
+class RootAdminSeeder extends Seeder
+{
+  const USER_NAME = 'RootAdmin';
+  const USER_EMAIL = 'root_admin@example.com';
+
+  public function run()
+  {
+    // RootAdminユーザーの作成
+    $password = SystemUserSeeder::generateComplexPassword();
+    $userId = new UserId();
+    $rootAdmin = User::create([
+      'id' => $userId->toString(),
+      'name' => self::USER_NAME,
+      'email' => self::USER_EMAIL,
+      'password' => Hash::make($password),
+      'email_verified_at' => now(),
+      'remember_token' => null,
+    ]);
+
+    // 管理者ロールの取得
+    $adminRole = EloquentRole::where('id', UserRolePolicyGroupSeeder::ADMIN_USER_ROLE_ID)->first();
+
+    if (!$adminRole) {
+      throw new \Exception('Admin role not found. Make sure UserRolePolicyGroupSeeder has been run.');
+    }
+
+    // UserRoleの作成
+    EloquentUserRole::factory()
+      ->forUser($rootAdmin->id)
+      ->forRole($adminRole->id)
+      ->assignedBy(SystemUserSeeder::SYSTEM_USER_UUID) // SystemUserが割り当てたとする
+      ->create();
+
+    $this->command->info('Root Admin user created successfully with a complex password and assigned admin role.');
+    $this->command->info('UserId: ' . $userId->toString());
+    $this->command->info('Username: ' . self::USER_NAME);
+    $this->command->info('UserEmail: ' . self::USER_EMAIL);
+    $this->command->info('Password: ' . $password);
+    $this->command->warn('WARNING: This password is displayed. In a production environment, never log or display passwords.');
+  }
+}

--- a/src/laravel/database/seeders/SystemUserSeeder.php
+++ b/src/laravel/database/seeders/SystemUserSeeder.php
@@ -14,7 +14,7 @@ class SystemUserSeeder extends Seeder
 
   public function run()
   {
-    $password = $this->generateComplexPassword();
+    $password = self::generateComplexPassword();
 
     User::create([
       'id' => self::SYSTEM_USER_UUID,
@@ -35,7 +35,7 @@ class SystemUserSeeder extends Seeder
    * @return string
    * @deprecated Passwordの生成はValueObjectで行うように移行する予定である。移行後削除する
    */
-  public function generateComplexPassword(): string
+  public static function generateComplexPassword(): string
   {
     $lowercase = 'abcdefghijklmnopqrstuvwxyz';
     $uppercase = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
@@ -68,7 +68,7 @@ class SystemUserSeeder extends Seeder
       || !preg_match('/[!@#$%^&*()\-_=+{};:,<.>]/', $password)
     ) {
       // 要件を満たさない場合は再帰的に再生成
-      return $this->generateComplexPassword();
+      return self::generateComplexPassword();
     }
 
     return $password;

--- a/src/laravel/database/seeders/SystemUserSeeder.php
+++ b/src/laravel/database/seeders/SystemUserSeeder.php
@@ -30,7 +30,7 @@ class SystemUserSeeder extends Seeder
     // $this->command->warn('WARNING: This password is displayed for testing purposes only. In a production environment, never log or display passwords.');
   }
 
-  private function generateComplexPassword(): string
+  public function generateComplexPassword(): string
   {
     $lowercase = 'abcdefghijklmnopqrstuvwxyz';
     $uppercase = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';

--- a/src/laravel/database/seeders/SystemUserSeeder.php
+++ b/src/laravel/database/seeders/SystemUserSeeder.php
@@ -30,6 +30,11 @@ class SystemUserSeeder extends Seeder
     // $this->command->warn('WARNING: This password is displayed for testing purposes only. In a production environment, never log or display passwords.');
   }
 
+  /**
+   * Summary of generateComplexPassword
+   * @return string
+   * @deprecated Passwordの生成はValueObjectで行うように移行する予定である。移行後削除する
+   */
   public function generateComplexPassword(): string
   {
     $lowercase = 'abcdefghijklmnopqrstuvwxyz';

--- a/src/laravel/database/seeders/UserPolicyGroupSeeder.php
+++ b/src/laravel/database/seeders/UserPolicyGroupSeeder.php
@@ -9,52 +9,57 @@ use App\Models\EloquentPolicy;
 
 class UserPolicyGroupSeeder extends Seeder
 {
+  public const GENERAL_USER_SELF_MANAGEMENT = 'policyGp-3522-493e-9967-82ebc40d399c';
+  public const ADMIN_USER_MANAGEMENT = 'policyGp-02ec-4281-b82e-49238e75c285';
+  public const PUBLIC_INFORMATION_ACCESS = 'policyGp-06f9-4a6e-8524-361c74a12291';
+  public const ACCESS_RESTRICTION = 'policyGp-d978-4d86-96a8-5a43303a83aa';
+
   public function run()
   {
     $policyGroups = [
       [
-        'id' => 'policyGp-3522-493e-9967-82ebc40d399c',
+        'id' => self::GENERAL_USER_SELF_MANAGEMENT,
         'name' => '一般ユーザー自己管理',
         'description' => '一般ユーザーが自身の情報を管理するためのポリシーグループ',
         'policies' => [
-          'policy00-3dcb-4d6b-99cb-f2d91c1f6f08', // ユーザー自己情報読み取り
-          'policy00-7d2d-4fdf-9c06-48cc8019acd4', // ユーザー自己情報更新
-          'policy00-25e8-441a-814b-38b6db46c79c', // ユーザーのパスワード変更
+          UserPolicySeeder::USER_SELF_READ, // ユーザー自己情報読み取り
+          UserPolicySeeder::USER_SELF_UPDATE, // ユーザー自己情報更新
+          UserPolicySeeder::USER_CHANGE_PASSWORD, // ユーザーのパスワード変更
         ]
       ],
       [
-        'id' => 'policyGp-02ec-4281-b82e-49238e75c285',
+        'id' => self::ADMIN_USER_MANAGEMENT,
         'name' => '管理者ユーザー管理',
         'description' => '管理者がユーザー情報を管理するためのポリシーグループ',
         'policies' => [
-          'policy00-1648-45eb-9fa5-c367382306fb', // 管理者によるユーザー作成
-          'policy00-4da7-4f01-97a0-6bf83ff38461', // 管理者によるユーザー読み取り
-          'policy00-e684-4929-b890-2ed0876a5488', // 管理者によるユーザー更新
-          'policy00-37bf-46a7-9229-b3156782e177', // 管理者によるユーザー削除
-          'policy00-96bc-4cfd-8b50-c013da891f93', // 管理者によるユーザー一覧表示
+          UserPolicySeeder::ADMIN_CREATE_USER, // 管理者によるユーザー作成
+          UserPolicySeeder::ADMIN_READ_USER, // 管理者によるユーザー読み取り
+          UserPolicySeeder::ADMIN_UPDATE_USER, // 管理者によるユーザー更新
+          UserPolicySeeder::ADMIN_DELETE_USER, // 管理者によるユーザー削除
+          UserPolicySeeder::ADMIN_LIST_USERS, // 管理者によるユーザー一覧表示
         ]
       ],
       [
-        'id' => 'policyGp-06f9-4a6e-8524-361c74a12291',
+        'id' => self::PUBLIC_INFORMATION_ACCESS,
         'name' => '公開情報アクセス',
         'description' => '誰でもアクセス可能な公開ユーザー情報に関するポリシーグループ',
         'policies' => [
-          'policy00-6584-4d8a-86bb-a954652ec511', // 公開ユーザー情報の読み取り
+          UserPolicySeeder::READ_PUBLIC_USER_INFO, // 公開ユーザー情報の読み取り
         ]
       ],
       [
-        'id' => 'policyGp-d978-4d86-96a8-5a43303a83aa',
+        'id' => self::ACCESS_RESTRICTION,
         'name' => 'アクセス制限',
         'description' => 'ユーザーへのアクセスを制限するポリシーグループ',
         'policies' => [
-          'policy00-1c1a-406d-8847-e9ab41238f50', // ユーザーアクセス不可（管理者例外あり）
+          UserPolicySeeder::DENY_INACCESSIBLE_USER, // ユーザーアクセス不可（管理者例外あり）
         ]
       ],
     ];
 
     foreach ($policyGroups as $group) {
       $policyGroup = EloquentPolicyGroup::create([
-        'id'=>(new PolicyGroupId($group['id']))->toString(),
+        'id' => (new PolicyGroupId($group['id']))->toString(),
         'name' => $group['name'],
         'description' => $group['description'],
       ]);

--- a/src/laravel/database/seeders/UserPolicyGroupSeeder.php
+++ b/src/laravel/database/seeders/UserPolicyGroupSeeder.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Domain\ValueObjects\PolicyGroupId;
+use Illuminate\Database\Seeder;
+use App\Models\EloquentPolicyGroup;
+use App\Models\EloquentPolicy;
+
+class UserPolicyGroupSeeder extends Seeder
+{
+  public function run()
+  {
+    $policyGroups = [
+      [
+        'id' => 'policyGp-3522-493e-9967-82ebc40d399c',
+        'name' => '一般ユーザー自己管理',
+        'description' => '一般ユーザーが自身の情報を管理するためのポリシーグループ',
+        'policies' => [
+          'policy00-3dcb-4d6b-99cb-f2d91c1f6f08', // ユーザー自己情報読み取り
+          'policy00-7d2d-4fdf-9c06-48cc8019acd4', // ユーザー自己情報更新
+          'policy00-25e8-441a-814b-38b6db46c79c', // ユーザーのパスワード変更
+        ]
+      ],
+      [
+        'id' => 'policyGp-02ec-4281-b82e-49238e75c285',
+        'name' => '管理者ユーザー管理',
+        'description' => '管理者がユーザー情報を管理するためのポリシーグループ',
+        'policies' => [
+          'policy00-1648-45eb-9fa5-c367382306fb', // 管理者によるユーザー作成
+          'policy00-4da7-4f01-97a0-6bf83ff38461', // 管理者によるユーザー読み取り
+          'policy00-e684-4929-b890-2ed0876a5488', // 管理者によるユーザー更新
+          'policy00-37bf-46a7-9229-b3156782e177', // 管理者によるユーザー削除
+          'policy00-96bc-4cfd-8b50-c013da891f93', // 管理者によるユーザー一覧表示
+        ]
+      ],
+      [
+        'id' => 'policyGp-06f9-4a6e-8524-361c74a12291',
+        'name' => '公開情報アクセス',
+        'description' => '誰でもアクセス可能な公開ユーザー情報に関するポリシーグループ',
+        'policies' => [
+          'policy00-6584-4d8a-86bb-a954652ec511', // 公開ユーザー情報の読み取り
+        ]
+      ],
+      [
+        'id' => 'policyGp-d978-4d86-96a8-5a43303a83aa',
+        'name' => 'アクセス制限',
+        'description' => 'ユーザーへのアクセスを制限するポリシーグループ',
+        'policies' => [
+          'policy00-1c1a-406d-8847-e9ab41238f50', // ユーザーアクセス不可（管理者例外あり）
+        ]
+      ],
+    ];
+
+    foreach ($policyGroups as $group) {
+      $policyGroup = EloquentPolicyGroup::create([
+        'id'=>(new PolicyGroupId($group['id']))->toString(),
+        'name' => $group['name'],
+        'description' => $group['description'],
+      ]);
+
+      $policies = EloquentPolicy::whereIn('id', $group['policies'])->get();
+      $policyGroup->policies()->attach($policies);
+    }
+  }
+}

--- a/src/laravel/database/seeders/UserPolicySeeder.php
+++ b/src/laravel/database/seeders/UserPolicySeeder.php
@@ -12,6 +12,7 @@ class UserPolicySeeder extends Seeder
   {
     $policies = [
       [
+        'id'=> 'policy00-3dcb-4d6b-99cb-f2d91c1f6f08',
         'name' => 'ユーザー自己情報読み取り',
         'description' => 'ユーザーが自分自身の情報を読み取ることを許可します。',
         'document' => [
@@ -30,6 +31,7 @@ class UserPolicySeeder extends Seeder
         ]
       ],
       [
+        'id' => 'policy00-7d2d-4fdf-9c06-48cc8019acd4',
         'name' => 'ユーザー自己情報更新',
         'description' => 'ユーザーが自分自身の情報を更新することを許可します。',
         'document' => [
@@ -48,6 +50,7 @@ class UserPolicySeeder extends Seeder
         ]
       ],
       [
+        'id' => 'policy00-1648-45eb-9fa5-c367382306fb',
         'name' => '管理者によるユーザー作成',
         'description' => '管理者がユーザーを作成することを許可します。',
         'document' => [
@@ -66,6 +69,7 @@ class UserPolicySeeder extends Seeder
         ]
       ],
       [
+        'id' => 'policy00-4da7-4f01-97a0-6bf83ff38461',
         'name' => '管理者によるユーザー読み取り',
         'description' => '管理者が任意のユーザーの情報を読み取ることを許可します。',
         'document' => [
@@ -84,6 +88,7 @@ class UserPolicySeeder extends Seeder
         ]
       ],
       [
+        'id' => 'policy00-e684-4929-b890-2ed0876a5488',
         'name' => '管理者によるユーザー更新',
         'description' => '管理者が任意のユーザーの情報を更新することを許可します。',
         'document' => [
@@ -102,6 +107,7 @@ class UserPolicySeeder extends Seeder
         ]
       ],
       [
+        'id' => 'policy00-37bf-46a7-9229-b3156782e177',
         'name' => '管理者によるユーザー削除',
         'description' => '管理者がユーザーを削除することを許可します。',
         'document' => [
@@ -120,6 +126,7 @@ class UserPolicySeeder extends Seeder
         ]
       ],
       [
+        'id' => 'policy00-96bc-4cfd-8b50-c013da891f93',
         'name' => '管理者によるユーザー一覧表示',
         'description' => '管理者がユーザー一覧を表示することを許可します。',
         'document' => [
@@ -138,6 +145,7 @@ class UserPolicySeeder extends Seeder
         ]
       ],
       [
+        'id' => 'policy00-25e8-441a-814b-38b6db46c79c',
         'name' => 'ユーザーのパスワード変更',
         'description' => 'ユーザーが自分自身のパスワードを変更することを許可します。',
         'document' => [
@@ -156,6 +164,7 @@ class UserPolicySeeder extends Seeder
         ]
       ],
       [
+        'id' => 'policy00-6584-4d8a-86bb-a954652ec511',
         'name' => '公開ユーザー情報の読み取り',
         'description' => '誰でも公開されているユーザー情報を読み取ることを許可します。',
         'document' => [
@@ -169,6 +178,7 @@ class UserPolicySeeder extends Seeder
         ]
       ],
       [
+        'id' => 'policy00-1c1a-406d-8847-e9ab41238f50',
         'name' => 'ユーザーアクセス不可（管理者例外あり）',
         'description' => 'このポリシーが適用されたユーザーへのアクセスを拒否します。ただし、root管理者と特定の管理者ロールは例外とします。',
         'document' => [
@@ -193,7 +203,7 @@ class UserPolicySeeder extends Seeder
 
     foreach ($policies as $policy) {
       EloquentPolicy::create([
-        'id' => (new PolicyId())->toString(),
+        'id' => (new PolicyId($policy['id']))->toString(),
         'name' => $policy['name'],
         'description' => $policy['description'],
         'document' => $policy['document'],

--- a/src/laravel/database/seeders/UserPolicySeeder.php
+++ b/src/laravel/database/seeders/UserPolicySeeder.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\EloquentPolicy;
+use Illuminate\Database\Seeder;
+use App\Domain\ValueObjects\PolicyId;
+
+class UserPolicySeeder extends Seeder
+{
+  public function run()
+  {
+    $policies = [
+      [
+        'name' => 'ユーザー自己情報読み取り',
+        'description' => 'ユーザーが自分自身の情報を読み取ることを許可します。',
+        'document' => [
+          'Version' => '2024-08-29',
+          'Statement' => [
+            'Sid' => 'AllowUserSelfRead',
+            'Effect' => 'Allow',
+            'Action' => ['read_user'],
+            'Resource' => ['/users/${user:id}'],
+            'Condition' => [
+              'StringEquals' => [
+                'user:id' => '${resource:owner}'
+              ]
+            ]
+          ]
+        ]
+      ],
+      [
+        'name' => 'ユーザー自己情報更新',
+        'description' => 'ユーザーが自分自身の情報を更新することを許可します。',
+        'document' => [
+          'Version' => '2024-08-29',
+          'Statement' => [
+            'Sid' => 'AllowUserSelfUpdate',
+            'Effect' => 'Allow',
+            'Action' => ['update_user'],
+            'Resource' => ['/users/${user:id}'],
+            'Condition' => [
+              'StringEquals' => [
+                'user:id' => '${resource:owner}'
+              ]
+            ]
+          ]
+        ]
+      ],
+      [
+        'name' => '管理者によるユーザー作成',
+        'description' => '管理者がユーザーを作成することを許可します。',
+        'document' => [
+          'Version' => '2024-08-29',
+          'Statement' => [
+            'Sid' => 'AllowAdminCreateUser',
+            'Effect' => 'Allow',
+            'Action' => ['create_user'],
+            'Resource' => ['/users/*'],
+            'Condition' => [
+              'StringLike' => [
+                'user:role' => ['admin', 'root_admin']
+              ]
+            ]
+          ]
+        ]
+      ],
+      [
+        'name' => '管理者によるユーザー読み取り',
+        'description' => '管理者が任意のユーザーの情報を読み取ることを許可します。',
+        'document' => [
+          'Version' => '2024-08-29',
+          'Statement' => [
+            'Sid' => 'AllowAdminReadUser',
+            'Effect' => 'Allow',
+            'Action' => ['read_user'],
+            'Resource' => ['/users/*'],
+            'Condition' => [
+              'StringLike' => [
+                'user:role' => ['admin', 'root_admin']
+              ]
+            ]
+          ]
+        ]
+      ],
+      [
+        'name' => '管理者によるユーザー更新',
+        'description' => '管理者が任意のユーザーの情報を更新することを許可します。',
+        'document' => [
+          'Version' => '2024-08-29',
+          'Statement' => [
+            'Sid' => 'AllowAdminUpdateUser',
+            'Effect' => 'Allow',
+            'Action' => ['update_user'],
+            'Resource' => ['/users/*'],
+            'Condition' => [
+              'StringLike' => [
+                'user:role' => ['admin', 'root_admin']
+              ]
+            ]
+          ]
+        ]
+      ],
+      [
+        'name' => '管理者によるユーザー削除',
+        'description' => '管理者がユーザーを削除することを許可します。',
+        'document' => [
+          'Version' => '2024-08-29',
+          'Statement' => [
+            'Sid' => 'AllowAdminDeleteUser',
+            'Effect' => 'Allow',
+            'Action' => ['delete_user'],
+            'Resource' => ['/users/*'],
+            'Condition' => [
+              'StringLike' => [
+                'user:role' => ['admin', 'root_admin']
+              ]
+            ]
+          ]
+        ]
+      ],
+      [
+        'name' => '管理者によるユーザー一覧表示',
+        'description' => '管理者がユーザー一覧を表示することを許可します。',
+        'document' => [
+          'Version' => '2024-08-29',
+          'Statement' => [
+            'Sid' => 'AllowAdminListUsers',
+            'Effect' => 'Allow',
+            'Action' => ['list_users'],
+            'Resource' => ['/users/*'],
+            'Condition' => [
+              'StringLike' => [
+                'user:role' => ['admin', 'root_admin']
+              ]
+            ]
+          ]
+        ]
+      ],
+      [
+        'name' => 'ユーザーのパスワード変更',
+        'description' => 'ユーザーが自分自身のパスワードを変更することを許可します。',
+        'document' => [
+          'Version' => '2024-08-29',
+          'Statement' => [
+            'Sid' => 'AllowUserPasswordChange',
+            'Effect' => 'Allow',
+            'Action' => ['update_user_password'],
+            'Resource' => ['/users/${user:id}'],
+            'Condition' => [
+              'StringEquals' => [
+                'user:id' => '${resource:owner}'
+              ]
+            ]
+          ]
+        ]
+      ],
+      [
+        'name' => '公開ユーザー情報の読み取り',
+        'description' => '誰でも公開されているユーザー情報を読み取ることを許可します。',
+        'document' => [
+          'Version' => '2024-08-29',
+          'Statement' => [
+            'Sid' => 'AllowPublicUserRead',
+            'Effect' => 'Allow',
+            'Action' => ['read_user_public_info'],
+            'Resource' => ['/users/*']
+          ]
+        ]
+      ],
+      [
+        'name' => 'ユーザーアクセス不可（管理者例外あり）',
+        'description' => 'このポリシーが適用されたユーザーへのアクセスを拒否します。ただし、root管理者と特定の管理者ロールは例外とします。',
+        'document' => [
+          'Version' => '2024-08-29',
+          'Statement' => [
+            'Sid' => 'DenyAccessToInaccessibleUser',
+            'Effect' => 'Deny',
+            'Action' => ['*'],
+            'Resource' => ['/users/${user:id}'],
+            'Condition' => [
+              'StringEquals' => [
+                'user:status' => 'inaccessible'
+              ],
+              'StringNotLike' => [
+                'user:role' => ['root_admin', 'system_admin', 'security_admin']
+              ]
+            ]
+          ]
+        ]
+      ]
+    ];
+
+    foreach ($policies as $policy) {
+      EloquentPolicy::create([
+        'id' => (new PolicyId())->toString(),
+        'name' => $policy['name'],
+        'description' => $policy['description'],
+        'document' => $policy['document'],
+      ]);
+    }
+  }
+}

--- a/src/laravel/database/seeders/UserPolicySeeder.php
+++ b/src/laravel/database/seeders/UserPolicySeeder.php
@@ -8,11 +8,21 @@ use App\Domain\ValueObjects\PolicyId;
 
 class UserPolicySeeder extends Seeder
 {
+  public const USER_SELF_READ = 'policy00-3dcb-4d6b-99cb-f2d91c1f6f08';
+  public const USER_SELF_UPDATE = 'policy00-7d2d-4fdf-9c06-48cc8019acd4';
+  public const ADMIN_CREATE_USER = 'policy00-1648-45eb-9fa5-c367382306fb';
+  public const ADMIN_READ_USER = 'policy00-4da7-4f01-97a0-6bf83ff38461';
+  public const ADMIN_UPDATE_USER = 'policy00-e684-4929-b890-2ed0876a5488';
+  public const ADMIN_DELETE_USER = 'policy00-37bf-46a7-9229-b3156782e177';
+  public const ADMIN_LIST_USERS = 'policy00-96bc-4cfd-8b50-c013da891f93';
+  public const USER_CHANGE_PASSWORD = 'policy00-25e8-441a-814b-38b6db46c79c';
+  public const READ_PUBLIC_USER_INFO = 'policy00-6584-4d8a-86bb-a954652ec511';
+  public const DENY_INACCESSIBLE_USER = 'policy00-1c1a-406d-8847-e9ab41238f50';
   public function run()
   {
     $policies = [
       [
-        'id'=> 'policy00-3dcb-4d6b-99cb-f2d91c1f6f08',
+        'id' => self::USER_SELF_READ,
         'name' => 'ユーザー自己情報読み取り',
         'description' => 'ユーザーが自分自身の情報を読み取ることを許可します。',
         'document' => [
@@ -31,7 +41,7 @@ class UserPolicySeeder extends Seeder
         ]
       ],
       [
-        'id' => 'policy00-7d2d-4fdf-9c06-48cc8019acd4',
+        'id' => self::USER_SELF_UPDATE,
         'name' => 'ユーザー自己情報更新',
         'description' => 'ユーザーが自分自身の情報を更新することを許可します。',
         'document' => [
@@ -50,7 +60,7 @@ class UserPolicySeeder extends Seeder
         ]
       ],
       [
-        'id' => 'policy00-1648-45eb-9fa5-c367382306fb',
+        'id' => self::ADMIN_CREATE_USER,
         'name' => '管理者によるユーザー作成',
         'description' => '管理者がユーザーを作成することを許可します。',
         'document' => [
@@ -69,7 +79,7 @@ class UserPolicySeeder extends Seeder
         ]
       ],
       [
-        'id' => 'policy00-4da7-4f01-97a0-6bf83ff38461',
+        'id' => self::ADMIN_READ_USER,
         'name' => '管理者によるユーザー読み取り',
         'description' => '管理者が任意のユーザーの情報を読み取ることを許可します。',
         'document' => [
@@ -88,7 +98,7 @@ class UserPolicySeeder extends Seeder
         ]
       ],
       [
-        'id' => 'policy00-e684-4929-b890-2ed0876a5488',
+        'id' => self::ADMIN_UPDATE_USER,
         'name' => '管理者によるユーザー更新',
         'description' => '管理者が任意のユーザーの情報を更新することを許可します。',
         'document' => [
@@ -107,7 +117,7 @@ class UserPolicySeeder extends Seeder
         ]
       ],
       [
-        'id' => 'policy00-37bf-46a7-9229-b3156782e177',
+        'id' => self::ADMIN_DELETE_USER,
         'name' => '管理者によるユーザー削除',
         'description' => '管理者がユーザーを削除することを許可します。',
         'document' => [
@@ -126,7 +136,7 @@ class UserPolicySeeder extends Seeder
         ]
       ],
       [
-        'id' => 'policy00-96bc-4cfd-8b50-c013da891f93',
+        'id' => self::ADMIN_LIST_USERS,
         'name' => '管理者によるユーザー一覧表示',
         'description' => '管理者がユーザー一覧を表示することを許可します。',
         'document' => [
@@ -145,7 +155,7 @@ class UserPolicySeeder extends Seeder
         ]
       ],
       [
-        'id' => 'policy00-25e8-441a-814b-38b6db46c79c',
+        'id' => self::USER_CHANGE_PASSWORD,
         'name' => 'ユーザーのパスワード変更',
         'description' => 'ユーザーが自分自身のパスワードを変更することを許可します。',
         'document' => [
@@ -164,7 +174,7 @@ class UserPolicySeeder extends Seeder
         ]
       ],
       [
-        'id' => 'policy00-6584-4d8a-86bb-a954652ec511',
+        'id' => self::READ_PUBLIC_USER_INFO,
         'name' => '公開ユーザー情報の読み取り',
         'description' => '誰でも公開されているユーザー情報を読み取ることを許可します。',
         'document' => [
@@ -178,7 +188,7 @@ class UserPolicySeeder extends Seeder
         ]
       ],
       [
-        'id' => 'policy00-1c1a-406d-8847-e9ab41238f50',
+        'id' => self::DENY_INACCESSIBLE_USER,
         'name' => 'ユーザーアクセス不可（管理者例外あり）',
         'description' => 'このポリシーが適用されたユーザーへのアクセスを拒否します。ただし、root管理者と特定の管理者ロールは例外とします。',
         'document' => [

--- a/src/laravel/database/seeders/UserRolePolicyGroupSeeder.php
+++ b/src/laravel/database/seeders/UserRolePolicyGroupSeeder.php
@@ -11,17 +11,20 @@ use App\Domain\ValueObjects\RoleDescription;
 
 class UserRolePolicyGroupSeeder extends Seeder
 {
+  public const GENERAL_USER_ROLE_ID = 'role0000-f8dd-4f7f-8a0c-e3061aa3f027';
   public const ADMIN_USER_ROLE_ID = 'role0000-cf39-44eb-94ad-9e2c31ffeb30';
+  public const SECURITY_ADMIN_ROLE_ID = 'role0000-7c67-43fa-ab72-ad41db433ddc';
+
   public function run()
   {
     $roles = [
       [
-        'id' => 'role0000-f8dd-4f7f-8a0c-e3061aa3f027',
+        'id' => self::GENERAL_USER_ROLE_ID,
         'name' => '一般ユーザー',
         'description' => '通常の利用者権限を持つロール',
         'policyGroups' => [
-          'policyGp-3522-493e-9967-82ebc40d399c', // 一般ユーザー自己管理
-          'policyGp-06f9-4a6e-8524-361c74a12291', // 公開情報アクセス
+          UserPolicyGroupSeeder::GENERAL_USER_SELF_MANAGEMENT,
+          UserPolicyGroupSeeder::PUBLIC_INFORMATION_ACCESS,
         ],
       ],
       [
@@ -29,20 +32,20 @@ class UserRolePolicyGroupSeeder extends Seeder
         'name' => '管理者',
         'description' => 'システム管理者権限を持つロール',
         'policyGroups' => [
-          'policyGp-3522-493e-9967-82ebc40d399c', // 一般ユーザー自己管理
-          'policyGp-02ec-4281-b82e-49238e75c285', // 管理者ユーザー管理
-          'policyGp-06f9-4a6e-8524-361c74a12291', // 公開情報アクセス
+          UserPolicyGroupSeeder::GENERAL_USER_SELF_MANAGEMENT,
+          UserPolicyGroupSeeder::ADMIN_USER_MANAGEMENT,
+          UserPolicyGroupSeeder::PUBLIC_INFORMATION_ACCESS,
         ],
       ],
       [
-        'id' => 'role0000-7c67-43fa-ab72-ad41db433ddc',
+        'id' => self::SECURITY_ADMIN_ROLE_ID,
         'name' => 'セキュリティ管理者',
         'description' => 'セキュリティ関連の特別な権限を持つロール',
         'policyGroups' => [
-          'policyGp-3522-493e-9967-82ebc40d399c', // 一般ユーザー自己管理
-          'policyGp-02ec-4281-b82e-49238e75c285', // 管理者ユーザー管理
-          'policyGp-06f9-4a6e-8524-361c74a12291', // 公開情報アクセス
-          'policyGp-d978-4d86-96a8-5a43303a83aa', // アクセス制限
+          UserPolicyGroupSeeder::GENERAL_USER_SELF_MANAGEMENT,
+          UserPolicyGroupSeeder::ADMIN_USER_MANAGEMENT,
+          UserPolicyGroupSeeder::PUBLIC_INFORMATION_ACCESS,
+          UserPolicyGroupSeeder::ACCESS_RESTRICTION,
         ],
       ],
     ];

--- a/src/laravel/database/seeders/UserRolePolicyGroupSeeder.php
+++ b/src/laravel/database/seeders/UserRolePolicyGroupSeeder.php
@@ -11,6 +11,7 @@ use App\Domain\ValueObjects\RoleDescription;
 
 class UserRolePolicyGroupSeeder extends Seeder
 {
+  public const ADMIN_USER_ROLE_ID = 'role0000-cf39-44eb-94ad-9e2c31ffeb30';
   public function run()
   {
     $roles = [
@@ -24,7 +25,7 @@ class UserRolePolicyGroupSeeder extends Seeder
         ],
       ],
       [
-        'id' => 'role0000-cf39-44eb-94ad-9e2c31ffeb30',
+        'id' => self::ADMIN_USER_ROLE_ID,
         'name' => '管理者',
         'description' => 'システム管理者権限を持つロール',
         'policyGroups' => [

--- a/src/laravel/database/seeders/UserRolePolicyGroupSeeder.php
+++ b/src/laravel/database/seeders/UserRolePolicyGroupSeeder.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\EloquentRole;
+use App\Models\EloquentPolicyGroup;
+use App\Domain\ValueObjects\RoleId;
+use App\Domain\ValueObjects\RoleName;
+use App\Domain\ValueObjects\RoleDescription;
+
+class UserRolePolicyGroupSeeder extends Seeder
+{
+  public function run()
+  {
+    $roles = [
+      [
+        'id' => 'role0000-f8dd-4f7f-8a0c-e3061aa3f027',
+        'name' => '一般ユーザー',
+        'description' => '通常の利用者権限を持つロール',
+        'policyGroups' => [
+          'policyGp-3522-493e-9967-82ebc40d399c', // 一般ユーザー自己管理
+          'policyGp-06f9-4a6e-8524-361c74a12291', // 公開情報アクセス
+        ],
+      ],
+      [
+        'id' => 'role0000-cf39-44eb-94ad-9e2c31ffeb30',
+        'name' => '管理者',
+        'description' => 'システム管理者権限を持つロール',
+        'policyGroups' => [
+          'policyGp-3522-493e-9967-82ebc40d399c', // 一般ユーザー自己管理
+          'policyGp-02ec-4281-b82e-49238e75c285', // 管理者ユーザー管理
+          'policyGp-06f9-4a6e-8524-361c74a12291', // 公開情報アクセス
+        ],
+      ],
+      [
+        'id' => 'role0000-7c67-43fa-ab72-ad41db433ddc',
+        'name' => 'セキュリティ管理者',
+        'description' => 'セキュリティ関連の特別な権限を持つロール',
+        'policyGroups' => [
+          'policyGp-3522-493e-9967-82ebc40d399c', // 一般ユーザー自己管理
+          'policyGp-02ec-4281-b82e-49238e75c285', // 管理者ユーザー管理
+          'policyGp-06f9-4a6e-8524-361c74a12291', // 公開情報アクセス
+          'policyGp-d978-4d86-96a8-5a43303a83aa', // アクセス制限
+        ],
+      ],
+    ];
+
+    foreach ($roles as $roleData) {
+      $role = EloquentRole::create([
+        'id' => (new RoleId($roleData['id']))->toString(),
+        'name' => (new RoleName($roleData['name']))->toString(),
+        'description' => (new RoleDescription($roleData['description']))->toString(),
+      ]);
+
+      $policyGroups = EloquentPolicyGroup::whereIn('id', $roleData['policyGroups'])->get();
+      $role->policyGroups()->attach($policyGroups);
+    }
+  }
+}


### PR DESCRIPTION
## 実施タスク
[対象のissue] : <!-- ここを置き換える -->　#271 

## 実施内容
<!-- 作成内容・何を変更したか -->
<!-- 過去形で箇条書きで記載する -->

<!-- 例： -->
<!-- - 管理画面の作成を行いました -->
<!-- - 管理画面周りのUIテストコードを追加しました -->

## レビューしてほしいこと
<!-- 実装した箇所の明示 -->
<!-- 全体としてコードについてよりかは実装結果・内容について聞く -->
### 実装した箇所
<!-- 変更したURLパス・対象の画像 -->

<!-- 例： -->
<!-- 変更したURLパス -->

<!-- 【変更前の対象の画像】 -->
<!-- 画像パス -->

<!-- 【変更後の対象の画像】 -->
<!-- 画像パス -->
- Userに関するRoleなどを作成できるSeederを作成した
- プロフィールに関してはAPIパスを/users/profileに変更して対応する

### 重点的にレビューしてほしいこと
<!-- **レビューしてほしい内容：** -->
<!-- 箇条書きでレビュー方法を記載する -->

<!-- 例 -->
<!-- テストケースに過不足がないこと -->

## 備考
<!-- 実装できていない点・不安・今後の予定などを記載する -->

<!-- 例 -->
<!-- - 管理画面で表示するモーダルについては、別PRで実装を行います -->

