### PR TITLE
fix : なぜなら、「fix : マークダウンの変換時にURLが画面幅を超えてしまう問題に対処する #364 」ため、「 break-w…

### DIFF
--- a/src/front/src/views/components/blocks/markdownRenderer/MarkdownRenderer.tsx
+++ b/src/front/src/views/components/blocks/markdownRenderer/MarkdownRenderer.tsx
@@ -130,7 +130,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
           a: ({ node, href, children, ...props }) => {
             return (
               <a
-                className="text-blue-600 hover:underline dark:text-blue-400"
+                className="text-blue-600 hover:underline dark:text-blue-400 break-words"
                 target="_blank"
                 rel="noopener noreferrer"
                 href={href}


### PR DESCRIPTION
…ordsを追加することで 」 修正 した